### PR TITLE
Collaboration: shared Projects + shared chats with live sync

### DIFF
--- a/src/app/api/collab/accept/route.ts
+++ b/src/app/api/collab/accept/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server'
+import { createServerSupabaseClient, createServiceSupabaseClient } from '@/lib/supabase-server'
+import type { CollabInviteRow } from '@/lib/collab'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// /api/collab/accept — POST { token }
+//
+// Opening an invite link mints a real membership row; from then on access
+// flows from membership (RLS), never from the token. Runs with the service
+// client because the acceptor has no RLS visibility into the space yet.
+//
+// Rules:
+//   • expired or unknown token → 404/410
+//   • email-bound invites only accept the matching account (case-insensitive)
+//   • the space owner opening their own link is a no-op success
+//   • email invites are single-use (deleted on accept); link invites stay
+//     valid until they expire or are revoked, so one link can onboard a team
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function POST(req: Request) {
+  const supabase = await createServerSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const service = createServiceSupabaseClient()
+  if (!service) {
+    console.error('[collab:accept] SUPABASE_SERVICE_ROLE_KEY not configured')
+    return NextResponse.json({ error: 'server_misconfigured' }, { status: 500 })
+  }
+
+  const { token } = await req.json().catch(() => ({})) as { token?: string }
+  if (!token || typeof token !== 'string') {
+    return NextResponse.json({ error: 'missing_token' }, { status: 400 })
+  }
+
+  const { data: invite } = await service
+    .from('collab_invites')
+    .select('*')
+    .eq('token', token)
+    .maybeSingle<CollabInviteRow>()
+
+  if (!invite) return NextResponse.json({ error: 'invite_not_found' }, { status: 404 })
+  if (new Date(invite.expires_at).getTime() < Date.now()) {
+    return NextResponse.json({ error: 'invite_expired' }, { status: 410 })
+  }
+  if (invite.email && invite.email.toLowerCase() !== (user.email ?? '').toLowerCase()) {
+    return NextResponse.json({ error: 'invite_email_mismatch' }, { status: 403 })
+  }
+
+  // Resolve the target space (also tells us if the acceptor is the owner).
+  let target: { kind: 'conversation' | 'chat_project'; id: string; name: string; ownerId: string }
+  if (invite.kind === 'conversation' && invite.project_id) {
+    const { data: conv } = await service
+      .from('projects')
+      .select('id, name, user_id')
+      .eq('id', invite.project_id)
+      .maybeSingle()
+    if (!conv) return NextResponse.json({ error: 'space_gone' }, { status: 410 })
+    target = { kind: 'conversation', id: conv.id, name: conv.name, ownerId: conv.user_id }
+  } else if (invite.kind === 'chat_project' && invite.chat_project_id) {
+    const { data: cp } = await service
+      .from('chat_projects')
+      .select('id, name, user_id')
+      .eq('id', invite.chat_project_id)
+      .maybeSingle()
+    if (!cp) return NextResponse.json({ error: 'space_gone' }, { status: 410 })
+    target = { kind: 'chat_project', id: cp.id, name: cp.name, ownerId: cp.user_id }
+  } else {
+    return NextResponse.json({ error: 'invite_malformed' }, { status: 400 })
+  }
+
+  // Owner re-opening their own link: nothing to mint.
+  if (target.ownerId !== user.id) {
+    const row = target.kind === 'conversation'
+      ? { project_id: target.id, user_id: user.id, invited_by: invite.invited_by }
+      : { chat_project_id: target.id, user_id: user.id, invited_by: invite.invited_by }
+    const table = target.kind === 'conversation' ? 'conversation_members' : 'chat_project_members'
+    const { error: insErr } = await service.from(table).insert(row)
+    // 23505 = already a member — fine, accepting twice is idempotent.
+    if (insErr && insErr.code !== '23505') {
+      console.error('[collab:accept] membership insert failed', insErr.code, insErr.message)
+      return NextResponse.json({ error: 'accept_failed' }, { status: 500 })
+    }
+  }
+
+  // Email-bound invites are single-use.
+  if (invite.email) {
+    await service.from('collab_invites').delete().eq('id', invite.id)
+  }
+
+  return NextResponse.json({
+    ok: true,
+    kind: target.kind,
+    id: target.id,
+    name: target.name,
+    alreadyOwner: target.ownerId === user.id,
+  })
+}

--- a/src/app/api/collab/invites/route.ts
+++ b/src/app/api/collab/invites/route.ts
@@ -1,0 +1,86 @@
+import { randomBytes } from 'crypto'
+import { NextResponse } from 'next/server'
+import { createServerSupabaseClient } from '@/lib/supabase-server'
+import type { InviteKind } from '@/lib/collab'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// /api/collab/invites
+// POST   — create an invite for a conversation or a Chat Project. Returns the
+//          /join/<token> link. RLS enforces that only someone with access to
+//          the target space can create one (collab_insert_invites).
+// DELETE — revoke an invite by id (?id=). RLS: creator or space owner.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function POST(req: Request) {
+  const supabase = await createServerSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await req.json().catch(() => ({})) as {
+    kind?: InviteKind
+    conversationId?: string
+    chatProjectId?: string
+    email?: string
+  }
+
+  const kind: InviteKind | null =
+    body.kind === 'conversation' || body.kind === 'chat_project' ? body.kind : null
+  if (!kind) return NextResponse.json({ error: 'invalid_kind' }, { status: 400 })
+
+  const targetId = kind === 'conversation' ? body.conversationId : body.chatProjectId
+  if (!targetId) return NextResponse.json({ error: 'missing_target' }, { status: 400 })
+
+  const email = typeof body.email === 'string' && body.email.trim()
+    ? body.email.trim().toLowerCase()
+    : null
+  if (email && !/.+@.+\..+/.test(email)) {
+    return NextResponse.json({ error: 'invalid_email' }, { status: 400 })
+  }
+
+  const token = randomBytes(24).toString('base64url')
+
+  // Insert with the caller's own client so the collab_insert_invites policy is
+  // the access check — no duplicated authorization logic here.
+  const { data: invite, error } = await supabase
+    .from('collab_invites')
+    .insert({
+      token,
+      kind,
+      chat_project_id: kind === 'chat_project' ? targetId : null,
+      project_id: kind === 'conversation' ? targetId : null,
+      email,
+      invited_by: user.id,
+    })
+    .select()
+    .single()
+
+  if (error) {
+    // 42501 = RLS rejection → the caller has no access to that space.
+    const status = error.code === '42501' ? 403 : 500
+    if (status === 500) console.error('[collab:invite-create]', error.code, error.message)
+    return NextResponse.json({ error: status === 403 ? 'forbidden' : 'create_failed' }, { status })
+  }
+
+  const origin = new URL(req.url).origin
+  return NextResponse.json({
+    invite,
+    joinUrl: `${origin}/join/${token}`,
+  })
+}
+
+export async function DELETE(req: Request) {
+  const supabase = await createServerSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const id = new URL(req.url).searchParams.get('id')
+  if (!id) return NextResponse.json({ error: 'missing_id' }, { status: 400 })
+
+  // RLS (collab_delete_invites) limits this to the creator or the space owner.
+  const { error } = await supabase.from('collab_invites').delete().eq('id', id)
+  if (error) {
+    console.error('[collab:invite-delete]', error.code, error.message)
+    return NextResponse.json({ error: 'delete_failed' }, { status: 500 })
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/collab/members/route.ts
+++ b/src/app/api/collab/members/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from 'next/server'
+import { createServerSupabaseClient, createServiceSupabaseClient } from '@/lib/supabase-server'
+import {
+  canAccessConversation,
+  canAccessChatProject,
+  resolveProfiles,
+  type MemberProfile,
+} from '@/lib/collab'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// /api/collab/members
+// GET    — ?conversationId= | ?chatProjectId= → members (owner first) with
+//          display names, plus pending invites for the share modal.
+// DELETE — ?conversationId=&userId= | ?chatProjectId=&userId= → remove a
+//          member (owner removes anyone; a member removes themself).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function GET(req: Request) {
+  const supabase = await createServerSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const service = createServiceSupabaseClient()
+  if (!service) return NextResponse.json({ error: 'server_misconfigured' }, { status: 500 })
+
+  const url = new URL(req.url)
+  const conversationId = url.searchParams.get('conversationId')
+  const chatProjectId = url.searchParams.get('chatProjectId')
+  if (!conversationId && !chatProjectId) {
+    return NextResponse.json({ error: 'missing_target' }, { status: 400 })
+  }
+
+  let ownerId: string
+  let memberRows: { user_id: string; created_at: string }[]
+  if (conversationId) {
+    if (!(await canAccessConversation(service, conversationId, user.id))) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+    }
+    const { data: conv } = await service
+      .from('projects').select('user_id').eq('id', conversationId).single()
+    ownerId = conv!.user_id
+    const { data } = await service
+      .from('conversation_members')
+      .select('user_id, created_at')
+      .eq('project_id', conversationId)
+      .order('created_at', { ascending: true })
+    memberRows = data ?? []
+  } else {
+    if (!(await canAccessChatProject(service, chatProjectId!, user.id))) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+    }
+    const { data: cp } = await service
+      .from('chat_projects').select('user_id').eq('id', chatProjectId!).single()
+    ownerId = cp!.user_id
+    const { data } = await service
+      .from('chat_project_members')
+      .select('user_id, created_at')
+      .eq('chat_project_id', chatProjectId!)
+      .order('created_at', { ascending: true })
+    memberRows = data ?? []
+  }
+
+  const profiles = await resolveProfiles(service, [ownerId, ...memberRows.map((m) => m.user_id)])
+  const members: MemberProfile[] = [
+    {
+      user_id: ownerId,
+      role: 'owner',
+      display_name: profiles.get(ownerId)?.display_name ?? 'Owner',
+      email: profiles.get(ownerId)?.email ?? null,
+    },
+    ...memberRows.map((m): MemberProfile => ({
+      user_id: m.user_id,
+      role: 'editor',
+      display_name: profiles.get(m.user_id)?.display_name ?? 'Member',
+      email: profiles.get(m.user_id)?.email ?? null,
+    })),
+  ]
+
+  // Author profiles: every distinct created_by in this conversation's tree.
+  // Needed because a conversation inside a shared Chat Project has authors who
+  // are project members, not conversation members — the avatar chips still
+  // need their names.
+  let authors: MemberProfile[] = []
+  if (conversationId) {
+    const { data: authorRows } = await service
+      .from('nodes')
+      .select('created_by')
+      .eq('project_id', conversationId)
+      .not('created_by', 'is', null)
+    const ids = [...new Set((authorRows ?? []).map((r) => r.created_by as string))]
+      .filter((id) => id !== ownerId && !memberRows.some((m) => m.user_id === id))
+    if (ids.length) {
+      const authorProfiles = await resolveProfiles(service, ids)
+      authors = ids.map((id): MemberProfile => ({
+        user_id: id,
+        role: 'editor',
+        display_name: authorProfiles.get(id)?.display_name ?? 'Member',
+        email: authorProfiles.get(id)?.email ?? null,
+      }))
+    }
+  }
+
+  // Pending invites — the caller's own RLS view (members may see them).
+  const inviteQuery = supabase
+    .from('collab_invites')
+    .select('id, token, kind, email, created_at, expires_at')
+    .gt('expires_at', new Date().toISOString())
+  const { data: invites } = conversationId
+    ? await inviteQuery.eq('project_id', conversationId)
+    : await inviteQuery.eq('chat_project_id', chatProjectId!)
+
+  return NextResponse.json({ members, authors, invites: invites ?? [], me: user.id })
+}
+
+export async function DELETE(req: Request) {
+  const supabase = await createServerSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const url = new URL(req.url)
+  const conversationId = url.searchParams.get('conversationId')
+  const chatProjectId = url.searchParams.get('chatProjectId')
+  const userId = url.searchParams.get('userId')
+  if (!userId || (!conversationId && !chatProjectId)) {
+    return NextResponse.json({ error: 'missing_params' }, { status: 400 })
+  }
+
+  // The caller's own client: collab_delete_*_members policies allow exactly
+  // "self leaves" or "owner removes anyone".
+  const { error } = conversationId
+    ? await supabase.from('conversation_members').delete()
+        .eq('project_id', conversationId).eq('user_id', userId)
+    : await supabase.from('chat_project_members').delete()
+        .eq('chat_project_id', chatProjectId!).eq('user_id', userId)
+
+  if (error) {
+    console.error('[collab:member-delete]', error.code, error.message)
+    return NextResponse.json({ error: 'delete_failed' }, { status: 500 })
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/collab/shared/route.ts
+++ b/src/app/api/collab/shared/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server'
+import { createServerSupabaseClient, createServiceSupabaseClient } from '@/lib/supabase-server'
+import { resolveProfiles } from '@/lib/collab'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// /api/collab/shared — GET
+//
+// Everything shared WITH the current user, for the sidebar:
+//   • conversations  — one-off chats they were invited to
+//   • chatProjects   — team spaces they belong to (with chat counts + owner)
+//   • projectConversations — the chats living inside those team spaces
+//
+// Own spaces never appear here; /api/projects and /api/chat-projects stay the
+// source of truth for those (including their create-default behaviors).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function GET() {
+  const supabase = await createServerSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  // Membership rows are visible to their own user under RLS.
+  const [{ data: convMemberships }, { data: projMemberships }] = await Promise.all([
+    supabase.from('conversation_members').select('project_id').eq('user_id', user.id),
+    supabase.from('chat_project_members').select('chat_project_id').eq('user_id', user.id),
+  ])
+
+  const sharedConvIds = (convMemberships ?? []).map((m) => m.project_id)
+  const sharedProjectIds = (projMemberships ?? []).map((m) => m.chat_project_id)
+
+  if (!sharedConvIds.length && !sharedProjectIds.length) {
+    return NextResponse.json({ conversations: [], chatProjects: [], projectConversations: [] })
+  }
+
+  const [convRes, cpRes, cpConvRes] = await Promise.all([
+    sharedConvIds.length
+      ? supabase.from('projects').select('*').in('id', sharedConvIds)
+      : Promise.resolve({ data: [] as Record<string, unknown>[] }),
+    sharedProjectIds.length
+      ? supabase.from('chat_projects').select('*').in('id', sharedProjectIds)
+      : Promise.resolve({ data: [] as Record<string, unknown>[] }),
+    sharedProjectIds.length
+      ? supabase.from('projects').select('*').in('chat_project_id', sharedProjectIds)
+      : Promise.resolve({ data: [] as Record<string, unknown>[] }),
+  ])
+
+  const conversations = convRes.data ?? []
+  const chatProjectRows = (cpRes.data ?? []) as { id: string; user_id: string; [k: string]: unknown }[]
+  const projectConversations = (cpConvRes.data ?? []) as { chat_project_id: string | null; created_at: string }[]
+
+  // Owner names ("Shared by …") — best effort; missing service key degrades
+  // to plain rows.
+  const service = createServiceSupabaseClient()
+  const ownerProfiles = service
+    ? await resolveProfiles(service, chatProjectRows.map((p) => p.user_id))
+    : new Map<string, { display_name: string; email: string | null }>()
+
+  const chatProjects = chatProjectRows.map((p) => {
+    const inProject = projectConversations.filter((c) => c.chat_project_id === p.id)
+    const last = inProject.reduce<string | null>(
+      (acc, c) => (!acc || c.created_at > acc ? c.created_at : acc), null)
+    return {
+      ...p,
+      chat_count: inProject.length,
+      last_activity: last,
+      shared: true,
+      owner_name: ownerProfiles.get(p.user_id)?.display_name ?? null,
+    }
+  })
+
+  return NextResponse.json({ conversations, chatProjects, projectConversations })
+}

--- a/src/app/app/App.tsx
+++ b/src/app/app/App.tsx
@@ -5,6 +5,9 @@ import { useRouter } from 'next/navigation'
 import { track } from '@vercel/analytics'
 import { createClient } from '@/lib/supabase'
 import { trackEvent } from '@/lib/track-event'
+import { PENDING_JOIN_KEY } from '@/lib/collab-client'
+import type { DecisionStatus, NodeDecision } from '@/lib/decisions'
+import ShareModal from './ShareModal'
 import Sidebar from './Sidebar'
 import ChatPanel from './ChatPanel'
 import TreePanel from './TreePanel'
@@ -95,6 +98,21 @@ export interface ChatMessage {
    *  source_message_id) rather than being generated natively in Nodea. Drives
    *  whether the reply wears the source's icon or its native Claude model logo. */
   imported?: boolean
+  /** Author of the node (nodes.created_by). In shared spaces, messages from
+   *  other members wear their author's avatar chip. */
+  createdBy?: string | null
+}
+
+/** A collaborator profile, resolved via /api/collab/members. */
+export interface CollabProfile {
+  name: string
+  email: string | null
+}
+
+/** Who else is live in the active conversation right now (presence). */
+export interface PresencePeer {
+  userId: string
+  name: string
 }
 
 export interface NodeAttachment {
@@ -176,6 +194,7 @@ function dbNodeToMessage(n: DbNode): ChatMessage {
       attachments: attachments.length > 0
         ? attachments.map((a) => ({ name: a.name, type: a.type, dataUrl: a.url ?? '' }))
         : undefined,
+      createdBy: n.created_by ?? null,
     }
   }
   return {
@@ -183,6 +202,7 @@ function dbNodeToMessage(n: DbNode): ChatMessage {
     timestamp: new Date(n.created_at).getTime(),
     modelId: n.model_id ?? undefined,
     imported: !!n.source_message_id,
+    createdBy: n.created_by ?? null,
   }
 }
 
@@ -377,6 +397,17 @@ export interface DbNode {
   // branches here. See the merge_sources migration. Lives on the user node of
   // a pair (the node that owns the next prompt's generation context).
   merge_sources?: string[] | null
+  // Author (auth.users id). Stamped on insert so shared trees attribute every
+  // message; backfilled to the conversation owner for pre-collab rows.
+  created_by?: string | null
+  // ── Decision tag (decision layer, Tier A) ──
+  // Where this node sits in a decision: a kept path ('decided'), a ruled-out
+  // option ('rejected'), an open question ('undecided'), etc. Lives on the user
+  // node of a pair (the branch the user took). Null/absent = untagged.
+  decision_status?: DecisionStatus | null
+  decision_note?: string | null
+  decided_by?: string | null
+  decided_at?: string | null
 }
 
 // A reversible node deletion. We snapshot the deleted rows (parent-first, so a
@@ -435,6 +466,10 @@ export interface AppContextType {
   isPro: boolean
   nodeColors: Record<string, string>
   setNodeColor: (id: string, color: string) => void
+  /** Decision tag per node id (keyed on the pair / user node). Absent = untagged. */
+  nodeDecisions: Record<string, NodeDecision>
+  /** Tag a node's decision status (+ optional note), or clear it with status=null. */
+  setNodeDecision: (id: string, status: DecisionStatus | null, note?: string | null) => void
   /** Delete a prompt+reply pair. Returns false (no-op) if it has branches below. */
   deleteNode: (pairId: string) => Promise<boolean>
   // ── Merge overlay ──
@@ -476,6 +511,20 @@ export interface AppContextType {
   openProjectContext: (project: ChatProject, x: number, y: number) => void
   assignConvToProject: (convId: string, projectId: string | null) => Promise<void>
   requestNewChatInProject: (projectId: string, initialMessage?: string, attachments?: AttachmentItem[]) => Promise<void>
+  // ── Collaboration ──
+  /** The signed-in user's id — lets the UI tell "mine" from "shared with me". */
+  myUserId: string | null
+  /** Author profiles for the active shared space (user id → name). */
+  collabProfiles: Record<string, CollabProfile>
+  /** Other members currently viewing the active conversation (live presence). */
+  presencePeers: PresencePeer[]
+  /** True when the active conversation is shared (someone else's, has members,
+   *  or lives in a shared project) — drives avatars + presence UI. */
+  activeConvIsShared: boolean
+  /** Open the share modal for a conversation or a chat project. */
+  openShareModal: (target: { kind: 'conversation' | 'chat_project'; id: string; name: string }) => void
+  /** Re-fetch everything shared with me (after accepting an invite, leaving, …). */
+  reloadShared: () => Promise<void>
 }
 
 export const AppContext = createContext<AppContextType>({} as AppContextType)
@@ -585,12 +634,24 @@ export default function App() {
   const [settingsInitialSection, setSettingsInitialSection] = useState<string | null>(null)
   const [userEmail,     setUserEmail]       = useState('')
   const [userName,      setUserName]        = useState('')
+  // ── Collaboration state ──
+  const [myUserId,      setMyUserId]        = useState<string | null>(null)
+  const [collabProfiles, setCollabProfiles] = useState<Record<string, CollabProfile>>({})
+  const [presencePeers, setPresencePeers]   = useState<PresencePeer[]>([])
+  const [sharedChatProjects, setSharedChatProjects] = useState<ChatProject[]>([])
+  const [shareTarget, setShareTarget] = useState<
+    { kind: 'conversation' | 'chat_project'; id: string; name: string } | null
+  >(null)
+  // Mirror for async closures (saveUserNode / saveAssistantNode stamp authors).
+  const myUserIdRef = useRef<string | null>(null)
+  useEffect(() => { myUserIdRef.current = myUserId }, [myUserId])
   // Flips true once the user is confirmed signed in (and named). Gates the
   // replay of a parked extension import — see PENDING_IMPORT_KEY.
   const [authedReady,   setAuthedReady]     = useState(false)
   const [isAdmin,       setIsAdmin]         = useState(false)
   const [isPro,         setIsPro]           = useState(false)
   const [nodeColors,    setNodeColors]      = useState<Record<string, string>>({})
+  const [nodeDecisions, setNodeDecisions]   = useState<Record<string, NodeDecision>>({})
   const [nodeSummaries, setNodeSummaries]   = useState<Record<string, { title: string; summary: string }>>({})
   const [pendingAttachments, setPendingAttachments] = useState<AttachmentItem[]>([])
   const [lastSavedPairId, setLastSavedPairId] = useState<string | null>(null)
@@ -736,6 +797,26 @@ export default function App() {
       .then(({ error }) => { if (error) console.error('Color save failed', error) })
   }, [supabase])
 
+  // ── Node decision tag — persist to DB (decision layer, Tier A) ─────────────
+  // status=null clears the tag. Stamps the current user + time as the decider
+  // (lightweight authorship; the Tier C events log is the full audit trail).
+  const setNodeDecision = useCallback((id: string, status: DecisionStatus | null, note?: string | null) => {
+    setNodeDecisions((prev) => {
+      const next = { ...prev }
+      if (status) next[id] = { status, note: note ?? null }
+      else delete next[id]
+      return next
+    })
+    const patch = status
+      ? { decision_status: status, decision_note: note ?? null, decided_by: myUserIdRef.current, decided_at: new Date().toISOString() }
+      : { decision_status: null, decision_note: null, decided_by: null, decided_at: null }
+    supabase
+      .from('nodes')
+      .update(patch)
+      .eq('id', id)
+      .then(({ error }) => { if (error) console.error('Decision save failed', error) })
+  }, [supabase])
+
   // ── Load conversation from DB into state ──────────────────────────────────
   const loadConversation = useCallback(
     async (convId: string, name: string) => {
@@ -746,6 +827,7 @@ export default function App() {
       setMessages([])
       setSelectedNodeId(null)
       setNodeColors({})
+      setNodeDecisions({})
       setNodeSummaries({})
       setHighlightedMessageId(null)
       setMemorySavedByMsgId({})
@@ -776,6 +858,13 @@ export default function App() {
         if (n.color) colorMap[n.id] = n.color
       }
       setNodeColors(colorMap)
+
+      // Restore persisted decision tags
+      const decisionMap: Record<string, NodeDecision> = {}
+      for (const n of enriched) {
+        if (n.decision_status) decisionMap[n.id] = { status: n.decision_status, note: n.decision_note ?? null }
+      }
+      setNodeDecisions(decisionMap)
 
       // Restore AI-generated titles/summaries from localStorage
       const metaMap: Record<string, { title: string; summary: string }> = {}
@@ -1277,6 +1366,9 @@ export default function App() {
     if (messages.length > 0) return null
     const oldId = activeConvId
     const oldConv = conversations.find((c) => c.id === oldId)
+    // Never reap a conversation that isn't mine (a shared space someone else
+    // owns) — empty or not, leaving it is their call.
+    if (oldConv && myUserIdRef.current && oldConv.user_id !== myUserIdRef.current) return null
     setConversations((prev) => prev.filter((c) => c.id !== oldId))
     // Keep the in-memory project chat_count honest. It's recomputed from real
     // rows on the next load, but if we reap a conv mid-session without
@@ -1293,6 +1385,212 @@ export default function App() {
   }, [activeConvId, isCurrentLoaded, allDbNodes, messages, conversations, supabase])
 
   // ── Bootstrap ─────────────────────────────────────────────────────────────
+  // ─── Collaboration: shared spaces, invites, live profiles ──────────────────
+
+  // Normalize a raw shared `projects` row into the client Conversation shape.
+  const normalizeSharedConv = useCallback((p: Conversation): Conversation => ({
+    ...p,
+    chat_project_id: p.chat_project_id ?? null,
+    source: p.source ?? null,
+  }), [])
+
+  // Re-fetch everything shared with me and reconcile the in-memory lists:
+  // keeps my own conversations untouched, adds newly-shared ones, and drops
+  // shared ones I've left (or was removed from).
+  const reloadShared = useCallback(async () => {
+    try {
+      const res = await fetch('/api/collab/shared')
+      if (!res.ok) return
+      const data = await res.json() as {
+        conversations: Conversation[]
+        chatProjects: ChatProject[]
+        projectConversations: Conversation[]
+      }
+      const shared = [...(data.conversations ?? []), ...(data.projectConversations ?? [])]
+      const freshIds = new Set(shared.map((c) => c.id))
+      setSharedChatProjects((data.chatProjects ?? []) as ChatProject[])
+      setConversations((prev) => {
+        const kept = prev.filter((c) => c.user_id === myUserIdRef.current || freshIds.has(c.id))
+        const keptIds = new Set(kept.map((c) => c.id))
+        const additions = shared.filter((c) => !keptIds.has(c.id)).map(normalizeSharedConv)
+        return [...kept, ...additions]
+      })
+    } catch {
+      // Endpoint not deployed / offline — shared lists just don't refresh.
+    }
+  }, [normalizeSharedConv])
+
+  // Accept a parked invite token (stashed by /join when the user was signed
+  // out). Returns the joined space so init can route straight into it.
+  const acceptPendingJoin = useCallback(async (): Promise<{ kind: string; id: string } | null> => {
+    let token: string | null = null
+    try {
+      token = localStorage.getItem(PENDING_JOIN_KEY)
+      if (token) localStorage.removeItem(PENDING_JOIN_KEY)
+    } catch {}
+    if (!token) return null
+    try {
+      const res = await fetch('/api/collab/accept', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      })
+      const data = await res.json().catch(() => ({})) as { ok?: boolean; kind?: string; id?: string }
+      if (res.ok && data.ok && data.kind && data.id) return { kind: data.kind, id: data.id }
+    } catch {}
+    return null
+  }, [])
+
+  const openShareModal = useCallback(
+    (target: { kind: 'conversation' | 'chat_project'; id: string; name: string }) => {
+      setShareTarget(target)
+    }, [])
+
+  // Mirror of `conversations` readable from effects without re-subscribing.
+  const conversationsRef = useRef<Conversation[]>([])
+  useEffect(() => { conversationsRef.current = conversations }, [conversations])
+
+  // Shared chat-project ids — conversations inside them are shared spaces too.
+  const sharedProjectIdsRef = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    sharedProjectIdsRef.current = new Set(sharedChatProjects.map((p) => p.id))
+  }, [sharedChatProjects])
+
+  // Is the active conversation a shared space? Owner-side sharing (my conv,
+  // other people invited) needs a membership probe; member-side is knowable
+  // from ownership alone. Resolved per conversation switch; also loads the
+  // author/member profiles that drive avatars.
+  const [activeConvIsShared, setActiveConvIsShared] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    setActiveConvIsShared(false)
+    setCollabProfiles({})
+    setPresencePeers([])
+    if (!activeConvId || !myUserId) return
+
+    const conv = conversationsRef.current.find((c) => c.id === activeConvId)
+    void (async () => {
+      let shared =
+        (conv && conv.user_id !== myUserId) ||
+        (conv?.chat_project_id != null && sharedProjectIdsRef.current.has(conv.chat_project_id))
+
+      if (!shared) {
+        // My own conversation: shared iff it has direct members, or its chat
+        // project has members. Cheap indexed head-counts under RLS.
+        const probes = await Promise.all([
+          supabase.from('conversation_members')
+            .select('user_id', { count: 'exact', head: true })
+            .eq('project_id', activeConvId),
+          conv?.chat_project_id
+            ? supabase.from('chat_project_members')
+                .select('user_id', { count: 'exact', head: true })
+                .eq('chat_project_id', conv.chat_project_id)
+            : Promise.resolve({ count: 0 }),
+        ])
+        shared = probes.some((p) => (p.count ?? 0) > 0)
+      }
+      if (cancelled || !shared) return
+      setActiveConvIsShared(true)
+
+      try {
+        const res = await fetch(`/api/collab/members?conversationId=${activeConvId}`)
+        if (!res.ok || cancelled) return
+        const data = await res.json() as {
+          members: { user_id: string; display_name: string; email: string | null }[]
+          authors?: { user_id: string; display_name: string; email: string | null }[]
+        }
+        const map: Record<string, CollabProfile> = {}
+        for (const m of [...(data.members ?? []), ...(data.authors ?? [])]) {
+          map[m.user_id] = { name: m.display_name, email: m.email }
+        }
+        if (!cancelled) setCollabProfiles(map)
+      } catch {}
+    })()
+    return () => { cancelled = true }
+  }, [activeConvId, myUserId, supabase])
+
+  // ── Live tree sync + presence ───────────────────────────────────────────────
+  // Shared conversations subscribe to node INSERT/UPDATE for this tree (RLS
+  // scopes events to members) and join a presence channel so everyone sees
+  // who's here. Append-only trees make this conflict-free: a simultaneous
+  // edit elsewhere is just another branch arriving.
+  const handleRemoteNodeInsert = useCallback((raw: DbNode) => {
+    if (raw.project_id !== activeConvIdRef.current) return
+    const enriched = enrichDbNodes([raw])[0]
+    setAllDbNodes((prev) => prev.some((n) => n.id === raw.id) ? prev : [...prev, enriched])
+    if (raw.color) setNodeColors((prev) => ({ ...prev, [raw.id]: raw.color! }))
+    if (raw.decision_status) setNodeDecisions((prev) => ({ ...prev, [raw.id]: { status: raw.decision_status!, note: raw.decision_note ?? null } }))
+    // Extend the visible thread only when the new node continues the path on
+    // screen — anything else shows up on the tree panel without yanking focus.
+    setMessages((prev) => {
+      if (!prev.length || prev.some((m) => m.id === raw.id)) return prev
+      if (raw.parent_id !== prev[prev.length - 1].id) return prev
+      if (raw.role === 'assistant' && lastNodeIdRef.current === raw.parent_id) {
+        lastNodeIdRef.current = raw.id
+      } else if (raw.role === 'user' && lastNodeIdRef.current === raw.parent_id) {
+        lastNodeIdRef.current = raw.id
+      }
+      return [...prev, dbNodeToMessage(enriched)]
+    })
+  }, [])
+
+  const handleRemoteNodeUpdate = useCallback((raw: DbNode) => {
+    if (raw.project_id !== activeConvIdRef.current) return
+    const enriched = enrichDbNodes([raw])[0]
+    setAllDbNodes((prev) => prev.map((n) => (n.id === raw.id ? { ...n, ...enriched } : n)))
+    setNodeColors((prev) => {
+      if ((prev[raw.id] ?? null) === (raw.color ?? null)) return prev
+      const next = { ...prev }
+      if (raw.color) next[raw.id] = raw.color
+      else delete next[raw.id]
+      return next
+    })
+    setNodeDecisions((prev) => {
+      const cur = prev[raw.id] ?? null
+      const incoming = raw.decision_status ?? null
+      if ((cur?.status ?? null) === incoming && (cur?.note ?? null) === (raw.decision_note ?? null)) return prev
+      const next = { ...prev }
+      if (incoming) next[raw.id] = { status: incoming, note: raw.decision_note ?? null }
+      else delete next[raw.id]
+      return next
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!activeConvId || !myUserId || !activeConvIsShared) return
+    const channel = supabase
+      .channel(`conv:${activeConvId}`, { config: { presence: { key: myUserId } } })
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'nodes', filter: `project_id=eq.${activeConvId}` },
+        (payload) => handleRemoteNodeInsert(payload.new as DbNode),
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'nodes', filter: `project_id=eq.${activeConvId}` },
+        (payload) => handleRemoteNodeUpdate(payload.new as DbNode),
+      )
+      .on('presence', { event: 'sync' }, () => {
+        const state = channel.presenceState<{ user_id: string; name: string }>()
+        const peers: PresencePeer[] = []
+        for (const key of Object.keys(state)) {
+          if (key === myUserId) continue
+          const meta = state[key][0]
+          if (meta) peers.push({ userId: meta.user_id, name: meta.name })
+        }
+        setPresencePeers(peers)
+      })
+      .subscribe((status) => {
+        if (status === 'SUBSCRIBED') {
+          void channel.track({ user_id: myUserId, name: userName || 'Someone' })
+        }
+      })
+    return () => {
+      void supabase.removeChannel(channel)
+      setPresencePeers([])
+    }
+  }, [activeConvId, myUserId, activeConvIsShared, userName, supabase, handleRemoteNodeInsert, handleRemoteNodeUpdate])
+
   useEffect(() => {
     async function init() {
       let { data: { user } } = await supabase.auth.getUser()
@@ -1313,6 +1611,8 @@ export default function App() {
       }
       setUserEmail(user.email ?? '')
       setUserName(displayName)
+      setMyUserId(user.id)
+      myUserIdRef.current = user.id
       setAuthedReady(true)
 
       const hardcodedAdmin = user.id === '64b415d7-4b59-4ff1-aa35-5f88de1599de'
@@ -1330,15 +1630,34 @@ export default function App() {
         setIsPro(dbAdmin || profile?.plan === 'pro')
       }
 
-      const res = await fetch('/api/projects')
-      if (!res.ok) { router.push('/login'); return }
-      const { projects } = await res.json()
-      if (!projects?.length) {
-        setConvName('')
-        return
+      // A parked invite (the user opened /join while signed out) is accepted
+      // BEFORE the lists load, so the joined space is already in them.
+      const joined = await acceptPendingJoin()
+
+      // Deep links from /join redirects: /app?conv=… or /app?project=…
+      const urlParams = new URLSearchParams(window.location.search)
+      const deepConvId = urlParams.get('conv') ?? (joined?.kind === 'conversation' ? joined.id : null)
+      const deepProjectId = urlParams.get('project') ?? (joined?.kind === 'chat_project' ? joined.id : null)
+      if (urlParams.has('conv') || urlParams.has('project')) {
+        window.history.replaceState({}, '', '/app')
       }
 
-      const normalized: Conversation[] = (projects as Conversation[]).map((p) => ({
+      const [res, sharedRes] = await Promise.all([
+        fetch('/api/projects'),
+        fetch('/api/collab/shared').catch(() => null),
+      ])
+      if (!res.ok) { router.push('/login'); return }
+      const { projects } = await res.json()
+
+      const sharedData = sharedRes?.ok
+        ? await sharedRes.json() as {
+            conversations: Conversation[]
+            chatProjects: ChatProject[]
+            projectConversations: Conversation[]
+          }
+        : { conversations: [], chatProjects: [], projectConversations: [] }
+
+      const normalized: Conversation[] = ((projects ?? []) as Conversation[]).map((p) => ({
         ...p,
         chat_project_id: p.chat_project_id ?? null,
         // The DB may not have the `source` column yet; restore it from the
@@ -1346,9 +1665,24 @@ export default function App() {
         // reads activeConvSource) survives a refresh.
         source: p.source ?? readImportedSource(p.id),
       }))
-      setConversations(normalized)
-      const lastId = localStorage.getItem('lastConvId')
-      const initial = normalized.find((p) => p.id === lastId) ?? normalized[0]
+      const ownIds = new Set(normalized.map((c) => c.id))
+      const sharedConvs = [...(sharedData.conversations ?? []), ...(sharedData.projectConversations ?? [])]
+        .filter((c) => !ownIds.has(c.id))
+        .map(normalizeSharedConv)
+      const merged = [...normalized, ...sharedConvs]
+      setConversations(merged)
+      setSharedChatProjects((sharedData.chatProjects ?? []) as ChatProject[])
+
+      if (deepProjectId) {
+        setActiveChatProjectId(deepProjectId)
+        setView('project')
+      }
+      if (!merged.length) {
+        setConvName('')
+        return
+      }
+      const lastId = deepConvId ?? localStorage.getItem('lastConvId')
+      const initial = merged.find((p) => p.id === lastId) ?? merged[0]
       await loadConversation(initial.id, initial.name)
     }
     init()
@@ -1708,12 +2042,22 @@ export default function App() {
   }, [supabase])
 
   // ── Delete conversation (Task 4) ──────────────────────────────────────────
+  // For a conversation someone else owns, "delete" means LEAVE: drop my
+  // membership row instead of destroying their tree (RLS would let a member
+  // empty the nodes, so this guard runs before any destructive call).
   const deleteConversation = useCallback(async (id: string) => {
-    await supabase.from('nodes').delete().eq('project_id', id)
-    const { error } = await supabase.from('projects').delete().eq('id', id)
-    if (error) { console.error('Delete failed', error); return }
-
-    track('conversation_deleted')
+    const conv = conversations.find((c) => c.id === id)
+    const mine = !conv || !myUserIdRef.current || conv.user_id === myUserIdRef.current
+    if (!mine) {
+      await fetch(`/api/collab/members?conversationId=${id}&userId=${myUserIdRef.current}`, { method: 'DELETE' })
+        .catch(() => {})
+      track('conversation_left')
+    } else {
+      await supabase.from('nodes').delete().eq('project_id', id)
+      const { error } = await supabase.from('projects').delete().eq('id', id)
+      if (error) { console.error('Delete failed', error); return }
+      track('conversation_deleted')
+    }
     // Drop any pending node-undo entries for this conversation — its rows are
     // gone for good, so Ctrl+Z must not try to restore them into a dead project.
     undoStackRef.current = undoStackRef.current.filter((e) => e.convId !== id)
@@ -1731,6 +2075,7 @@ export default function App() {
         setAllDbNodes([])
         setSelectedNodeId(null)
         setNodeColors({})
+        setNodeDecisions({})
         lastNodeIdRef.current = null
       }
     }
@@ -1761,7 +2106,14 @@ export default function App() {
       const persistedContent = serializeUserContent(userContent, attachmentMeta)
 
       const hasMerges = !!(mergeSources && mergeSources.length > 0)
-      const baseRow = { project_id: pid, parent_id: parentId, role: 'user' as const, content: persistedContent, position_x: 0, position_y: 0 }
+      // Author stamp — drives avatars in shared spaces. Falls away gracefully
+      // below if the column hasn't been migrated.
+      const author = myUserIdRef.current
+      const baseRow = {
+        project_id: pid, parent_id: parentId, role: 'user' as const, content: persistedContent,
+        position_x: 0, position_y: 0,
+        ...(author ? { created_by: author } : {}),
+      }
       const isColumnError = (e: { code?: string } | null) => e?.code === '42703' || e?.code === 'PGRST204'
       let mergeDropped = false
 
@@ -1792,6 +2144,16 @@ export default function App() {
           .select()
           .single())
       }
+      if (isColumnError(ue) && author) {
+        // Last resort: pre-collab schema without created_by.
+        const { created_by: _cb, ...legacyRow } = baseRow as typeof baseRow & { created_by?: string }
+        void _cb
+        ;({ data: userNode, error: ue } = await supabase
+          .from('nodes')
+          .insert(legacyRow)
+          .select()
+          .single())
+      }
       if (!ue && mergeDropped) notifyMergeUnavailable()
       if (ue || !userNode) {
         console.error('user node save failed', ue)
@@ -1819,7 +2181,10 @@ export default function App() {
       if (activeConvIdRef.current === pid) {
         lastNodeIdRef.current = userNode.id
         const userNodeWithAtt: DbNode = { ...(userNode as DbNode), attachments: attachmentMeta }
-        setAllDbNodes((prev) => [...prev, userNodeWithAtt])
+        // Dedupe: the live-sync channel may have delivered this insert already.
+        setAllDbNodes((prev) => prev.some((n) => n.id === userNodeWithAtt.id)
+          ? prev.map((n) => (n.id === userNodeWithAtt.id ? userNodeWithAtt : n))
+          : [...prev, userNodeWithAtt])
       }
       return userNode as DbNode
     },
@@ -1840,10 +2205,18 @@ export default function App() {
     ): Promise<string | null> => {
       if (!pid || !userNodeId) return null
 
-      const baseRow = { project_id: pid, parent_id: userNodeId, role: 'assistant', content: assistantContent, position_x: 0, position_y: 0 }
+      // The assistant node is authored by whoever sent the prompt — that's the
+      // account whose tokens were billed, and whose avatar the reply wears in
+      // a shared space.
+      const author = myUserIdRef.current
+      const baseRow = {
+        project_id: pid, parent_id: userNodeId, role: 'assistant', content: assistantContent,
+        position_x: 0, position_y: 0,
+        ...(author ? { created_by: author } : {}),
+      }
       // Stamp the model so the "Claude · {model}" label + logo survive a refresh.
       // Graceful-degrade exactly like attachments / merge_sources / provenance:
-      // if the model_id column isn't migrated yet, retry the insert without it.
+      // if the model_id / created_by columns aren't migrated yet, retry without.
       const isColumnError = (e: { code?: string } | null) => e?.code === '42703' || e?.code === 'PGRST204'
       let { data: asst, error: ae } = await supabase
         .from('nodes')
@@ -1854,6 +2227,15 @@ export default function App() {
         ;({ data: asst, error: ae } = await supabase
           .from('nodes')
           .insert(baseRow)
+          .select()
+          .single())
+      }
+      if (ae && author && isColumnError(ae)) {
+        const { created_by: _cb, ...legacyRow } = baseRow as typeof baseRow & { created_by?: string }
+        void _cb
+        ;({ data: asst, error: ae } = await supabase
+          .from('nodes')
+          .insert(legacyRow)
           .select()
           .single())
       }
@@ -1868,7 +2250,10 @@ export default function App() {
         lastNodeIdRef.current = asst.id
         setSelectedNodeId(asst.id)
         setLastSavedPairId(asst.id)
-        setAllDbNodes((prev) => [...prev, asst as DbNode])
+        // Dedupe: the live-sync channel may have delivered this insert already.
+        setAllDbNodes((prev) => prev.some((n) => n.id === (asst as DbNode).id)
+          ? prev
+          : [...prev, asst as DbNode])
       }
       return asst.id
     },
@@ -2537,6 +2922,9 @@ export default function App() {
       setNodeColors((prev) => {
         const next = { ...prev }; idList.forEach((id) => delete next[id]); return next
       })
+      setNodeDecisions((prev) => {
+        const next = { ...prev }; idList.forEach((id) => delete next[id]); return next
+      })
       setNodeSummaries((prev) => {
         const next = { ...prev }; idList.forEach((id) => delete next[id]); return next
       })
@@ -2589,7 +2977,17 @@ export default function App() {
           position_x: n.position_x, position_y: n.position_y, created_at: n.created_at,
         }
         if (n.color) row.color = n.color
+        if (n.decision_status) {
+          row.decision_status = n.decision_status
+          row.decision_note   = n.decision_note ?? null
+          row.decided_by      = n.decided_by ?? null
+          row.decided_at      = n.decided_at ?? null
+        }
         if (n.attachments && n.attachments.length) row.attachments = n.attachments
+        // Restoring someone else's node: the insert policy only accepts rows
+        // authored as myself (or unattributed), so a foreign author is dropped
+        // rather than failing the whole undo.
+        if (n.created_by && n.created_by === myUserIdRef.current) row.created_by = n.created_by
         let { error } = await supabase.from('nodes').insert(row)
         // Older schemas may lack the attachments column — retry without it (the
         // content still carries the inline attachment marker, so nothing is lost).
@@ -2604,6 +3002,12 @@ export default function App() {
       setNodeColors((prev) => {
         const next = { ...prev }
         for (const n of entry.nodes) { if (n.color) next[n.id] = n.color }
+        return next
+      })
+      // ...and any decision tags.
+      setNodeDecisions((prev) => {
+        const next = { ...prev }
+        for (const n of entry.nodes) { if (n.decision_status) next[n.id] = { status: n.decision_status, note: n.decision_note ?? null } }
         return next
       })
 
@@ -2654,6 +3058,13 @@ export default function App() {
   // with the source's own icon instead of the native model logo.
   const activeConvSource = conversations.find((c) => c.id === activeConvId)?.source ?? null
 
+  // Own projects + projects shared with me, deduped (own wins). Everything
+  // downstream (sidebar, landing, project page) renders this combined view.
+  const allChatProjects = useMemo(() => {
+    const ownIds = new Set(chatProjects.map((p) => p.id))
+    return [...chatProjects, ...sharedChatProjects.filter((p) => !ownIds.has(p.id))]
+  }, [chatProjects, sharedChatProjects])
+
   // ─────────────────────────────────────────────────────────────────────────
   const ctx: AppContextType = {
     conversations, activeConvId, convName, allDbNodes, messages, selectedNodeId,
@@ -2665,7 +3076,7 @@ export default function App() {
     renameConversation, deleteConversation,
     activeConvIsImported, activeConvSource, updateFromSource, isUpdatingSource, signOut,
     userEmail, userName, setUserName, isAdmin, isPro,
-    nodeColors, setNodeColor, deleteNode,
+    nodeColors, setNodeColor, nodeDecisions, setNodeDecision, deleteNode,
     canMergeInto, addMergeSource, removeMergeSource, beginMerge, mergeNotice, clearMergeNotice,
     nodeSummaries, chatInputRef,
     pendingAttachments, addAttachment, removeAttachment, clearAttachments,
@@ -2675,15 +3086,18 @@ export default function App() {
     settingsInitialSection, setSettingsInitialSection,
     memorySavedByMsgId,
     // ── Chat Projects ──
-    chatProjects, activeChatProjectId, view,
+    chatProjects: allChatProjects, activeChatProjectId, view,
     openProjectsLanding, openProject, openChatView,
     openNewProjectModal,
     openConvContext, openProjectContext,
     assignConvToProject, requestNewChatInProject,
+    // ── Collaboration ──
+    myUserId, collabProfiles, presencePeers, activeConvIsShared,
+    openShareModal, reloadShared,
   }
 
   const activeChatProject = activeChatProjectId
-    ? chatProjects.find((p) => p.id === activeChatProjectId) ?? null
+    ? allChatProjects.find((p) => p.id === activeChatProjectId) ?? null
     : null
 
   // Drag-target id for ProjectsLanding cards. Kept local; the Sidebar manages
@@ -2738,6 +3152,7 @@ export default function App() {
             onEdit={() => setProjectModalState({ mode: 'edit', project: activeChatProject })}
             onDelete={() => setDeleteProjectState(activeChatProject)}
             onSaveMemory={(memory) => saveProjectMemory(activeChatProject.id, memory)}
+            onShare={() => openShareModal({ kind: 'chat_project', id: activeChatProject.id, name: activeChatProject.name })}
           />
         )}
       </div>
@@ -2747,6 +3162,15 @@ export default function App() {
       {isSearchOpen  && <SearchModal />}
       {isSettingsOpen && <SettingsModal />}
       {isUpgradeOpen && <UpgradeModal />}
+
+      {/* Share modal (collaboration) */}
+      {shareTarget && (
+        <ShareModal
+          target={shareTarget}
+          onClose={() => setShareTarget(null)}
+          onMembershipChanged={() => void reloadShared()}
+        />
+      )}
 
       {/* Projects modals */}
       {projectModalState && (
@@ -2782,11 +3206,13 @@ export default function App() {
           conv={convMenu.conv}
           projects={chatProjects}
           isPro={isPro}
+          shared={!!myUserId && convMenu.conv.user_id !== myUserId}
           onMove={(pid) => assignConvToProject(convMenu.conv.id, pid)}
           onRemove={() => assignConvToProject(convMenu.conv.id, null)}
           onColor={(color) => setConvColor(convMenu.conv.id, color)}
           onEdit={() => setEditConvState(convMenu.conv)}
           onDelete={() => deleteConversation(convMenu.conv.id)}
+          onShare={() => openShareModal({ kind: 'conversation', id: convMenu.conv.id, name: convMenu.conv.name })}
           onUpgradeRequired={() => { setConvMenu(null); setIsUpgradeOpen(true) }}
           onClose={() => setConvMenu(null)}
         />

--- a/src/app/app/ChatPanel.tsx
+++ b/src/app/app/ChatPanel.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { track } from '@vercel/analytics'
 import { useApp, type AttachmentItem, type ChatMessage } from './App'
+import { avatarColor } from './ShareModal'
 import { modelDisplayName } from '@/lib/models'
 import { providerForModel, getAISource } from '@/lib/ai-sources'
 
@@ -487,7 +488,10 @@ function ImportedUpsellBanner() {
 
 // ── Top bar ───────────────────────────────────────────────────────────────────
 function TopBar() {
-  const { convName, setIsSearchOpen, setIsChatCollapsed, activeConvIsImported, updateFromSource, isUpdatingSource } = useApp()
+  const {
+    convName, setIsSearchOpen, setIsChatCollapsed, activeConvIsImported, updateFromSource, isUpdatingSource,
+    activeConvId, openShareModal, presencePeers, activeConvIsShared,
+  } = useApp()
 
   return (
     <div
@@ -507,6 +511,57 @@ function TopBar() {
         </span>
       </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
+        {/* Who else is here right now (live presence in shared spaces). */}
+        {presencePeers.length > 0 && (
+          <div style={{ display: 'flex', alignItems: 'center', marginRight: 8 }}>
+            {presencePeers.slice(0, 4).map((p, i) => (
+              <span
+                key={p.userId}
+                title={`${p.name} is viewing`}
+                style={{
+                  width: 24, height: 24, borderRadius: '50%',
+                  background: avatarColor(p.userId), color: '#fff',
+                  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 10.5, fontWeight: 700,
+                  border: '2px solid var(--topbar-bg)',
+                  marginLeft: i === 0 ? 0 : -7,
+                }}
+              >
+                {p.name.charAt(0).toUpperCase()}
+              </span>
+            ))}
+            {presencePeers.length > 4 && (
+              <span style={{ fontSize: 10.5, color: 'var(--text-muted)', marginLeft: 3 }}>
+                +{presencePeers.length - 4}
+              </span>
+            )}
+          </div>
+        )}
+        {activeConvId && (
+          <button
+            title="Share this chat"
+            onClick={() => openShareModal({ kind: 'conversation', id: activeConvId, name: convName })}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6, height: 30, padding: '0 10px', marginRight: 4,
+              background: activeConvIsShared ? 'var(--accent-bg)' : 'transparent',
+              border: `1px solid ${activeConvIsShared ? 'var(--user-bubble-border)' : 'var(--border)'}`,
+              borderRadius: 8,
+              cursor: 'pointer', color: activeConvIsShared ? 'var(--accent-text)' : 'var(--text-secondary)',
+              fontSize: 12.5, fontWeight: 600, whiteSpace: 'nowrap',
+              transition: 'background 0.1s, color 0.1s',
+            }}
+            onMouseEnter={(e) => { if (!activeConvIsShared) { const t = e.currentTarget as HTMLButtonElement; t.style.background = 'var(--bg-subtle)'; t.style.color = 'var(--text-primary)' } }}
+            onMouseLeave={(e) => { if (!activeConvIsShared) { const t = e.currentTarget as HTMLButtonElement; t.style.background = 'transparent'; t.style.color = 'var(--text-secondary)' } }}
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+              <circle cx="18" cy="5" r="3" />
+              <circle cx="6" cy="12" r="3" />
+              <circle cx="18" cy="19" r="3" />
+              <path d="M8.6 10.7l6.8-3.9M8.6 13.3l6.8 3.9" />
+            </svg>
+            {activeConvIsShared ? 'Shared' : 'Share'}
+          </button>
+        )}
         {activeConvIsImported && (
           <button
             title={isUpdatingSource ? 'Checking Claude for new branches…' : 'Pull any new branches in from Claude'}
@@ -752,7 +807,10 @@ function VersionArrow({ dir, disabled, onClick }: { dir: 'prev' | 'next'; disabl
 
 // ── Message ───────────────────────────────────────────────────────────────────
 function Message({ msg, isLast, isHighlighted }: { msg: ChatMessage; isLast: boolean; isHighlighted: boolean }) {
-  const { isLoading, memorySavedByMsgId, editUserMessage, promptVersionInfo, handleNodeClick, activeConvSource } = useApp()
+  const {
+    isLoading, memorySavedByMsgId, editUserMessage, promptVersionInfo, handleNodeClick, activeConvSource,
+    activeConvIsShared, collabProfiles, myUserId,
+  } = useApp()
   const savedMemories = !msg.role || msg.role === 'assistant' ? memorySavedByMsgId[msg.id] : undefined
   const isUser = msg.role === 'user'
   const isEmptyStreaming = isLast && isLoading && !isUser && !msg.content
@@ -872,6 +930,26 @@ function Message({ msg, isLast, isHighlighted }: { msg: ChatMessage; isLast: boo
                 {elapsed < 5 ? 'Thinking' : elapsed < 12 ? 'Processing' : 'Analyzing'} · {elapsed}s
               </span>
             )}
+          </div>
+        )}
+
+        {/* Author chip — only in shared spaces, only on other people's prompts. */}
+        {isUser && activeConvIsShared && msg.createdBy && msg.createdBy !== myUserId && (
+          <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+            <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-muted)' }}>
+              {collabProfiles[msg.createdBy]?.name ?? 'Teammate'}
+            </span>
+            <span
+              aria-hidden
+              style={{
+                width: 18, height: 18, borderRadius: '50%',
+                background: avatarColor(msg.createdBy), color: '#fff',
+                display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                fontSize: 9.5, fontWeight: 700, flexShrink: 0,
+              }}
+            >
+              {(collabProfiles[msg.createdBy]?.name ?? 'T').charAt(0).toUpperCase()}
+            </span>
           </div>
         )}
 

--- a/src/app/app/ConvContextMenu.tsx
+++ b/src/app/app/ConvContextMenu.tsx
@@ -15,11 +15,15 @@ interface Props {
   conv: Conversation
   projects: ChatProject[]
   isPro: boolean
+  /** Conversation owned by someone else (shared with me): no re-filing, and
+   *  "Delete" reads as "Leave" (the App-level delete already only leaves). */
+  shared?: boolean
   onMove: (projectId: string) => void
   onRemove: () => void
   onColor: (color: string | null) => void
   onEdit: () => void
   onDelete: () => void
+  onShare: () => void
   onUpgradeRequired: () => void
   onClose: () => void
 }
@@ -28,8 +32,8 @@ const MENU_WIDTH = 210
 const SUBMENU_WIDTH = 210
 
 export default function ConvContextMenu({
-  x, y, conv, projects, isPro,
-  onMove, onRemove, onColor, onEdit, onDelete, onUpgradeRequired, onClose,
+  x, y, conv, projects, isPro, shared,
+  onMove, onRemove, onColor, onEdit, onDelete, onShare, onUpgradeRequired, onClose,
 }: Props) {
   const elRef = useRef<HTMLDivElement | null>(null)
   const [submenu, setSubmenu] = useState<'project' | 'color' | null>(null)
@@ -84,8 +88,9 @@ export default function ConvContextMenu({
         padding: 5,
       }}
     >
-      {/* Move to project (submenu) */}
-      <div
+      {/* Move to project (submenu) — own conversations only; re-filing a
+          shared conversation would reorganize the owner's workspace. */}
+      {!shared && <div
         style={{ position: 'relative' }}
         onMouseEnter={() => setSubmenu('project')}
         onMouseLeave={() => setSubmenu(null)}
@@ -167,7 +172,7 @@ export default function ConvContextMenu({
             })}
           </div>
         )}
-      </div>
+      </div>}
 
       {/* Color (submenu) */}
       <div
@@ -255,7 +260,7 @@ export default function ConvContextMenu({
         )}
       </div>
 
-      {inProject && (
+      {inProject && !shared && (
         <button
           type="button"
           style={itemStyle}
@@ -270,6 +275,22 @@ export default function ConvContextMenu({
           Remove from project
         </button>
       )}
+
+      <button
+        type="button"
+        style={itemStyle}
+        onMouseEnter={(e) => hov(e, true)}
+        onMouseLeave={(e) => hov(e, false)}
+        onClick={() => { onShare(); onClose() }}
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.7 }}>
+          <circle cx="18" cy="5" r="3" />
+          <circle cx="6" cy="12" r="3" />
+          <circle cx="18" cy="19" r="3" />
+          <path d="M8.6 10.7l6.8-3.9M8.6 13.3l6.8 3.9" />
+        </svg>
+        Share
+      </button>
 
       <div style={{ height: 1, background: 'var(--border)', margin: '5px 8px' }} />
 
@@ -293,10 +314,17 @@ export default function ConvContextMenu({
         onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent' }}
         onClick={() => { onDelete(); onClose() }}
       >
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M4 6h16M9 6V4h6v2M6 6l1 14h10l1-14" />
-        </svg>
-        Delete
+        {shared ? (
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            <path d="M16 17l5-5-5-5M21 12H9" />
+          </svg>
+        ) : (
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4 6h16M9 6V4h6v2M6 6l1 14h10l1-14" />
+          </svg>
+        )}
+        {shared ? 'Leave shared chat' : 'Delete'}
       </button>
     </div>
   )

--- a/src/app/app/ProjectPage.tsx
+++ b/src/app/app/ProjectPage.tsx
@@ -32,6 +32,8 @@ interface Props {
   /** Persist the project's memory box. Rejects on failure so the editor can
    *  keep its draft and surface the error. */
   onSaveMemory: (memory: string) => Promise<void>
+  /** Open the share modal for this project. */
+  onShare: () => void
 }
 
 interface NodeRow {
@@ -61,9 +63,13 @@ function formatTime(iso: string): string {
 export default function ProjectPage({
   project, conversations, isPro, isAdmin,
   onBack, onOpenConv, onNewChat, onConvContext, onEdit, onDelete, onSaveMemory,
+  onShare,
 }: Props) {
   const supabase = useMemo(() => createClient(), [])
   const c = colorById(project.color)
+  // Shared-with-me projects belong to someone else: settings, deletion and the
+  // memory box stay the owner's (the API enforces this server-side too).
+  const isOwner = !project.shared
   const convs = useMemo(
     () => conversations
       .filter((cv) => cv.chat_project_id === project.id)
@@ -292,6 +298,9 @@ export default function ProjectPage({
             <div style={{ fontSize: 13, color: 'var(--text-muted)', marginTop: 3 }}>
               {convs.length} conversation{convs.length === 1 ? '' : 's'}
               {project.last_activity && <> · last active {formatTime(project.last_activity)}</>}
+              {project.shared && (
+                <> · shared by <strong style={{ fontWeight: 600, color: 'var(--text-secondary)' }}>{project.owner_name ?? 'a teammate'}</strong></>
+              )}
             </div>
             {project.description && (
               <p style={{
@@ -304,29 +313,53 @@ export default function ProjectPage({
           </div>
 
           <button
-            ref={menuBtnRef}
             type="button"
-            onClick={() => setMenuOpen((m) => !m)}
-            title="Project settings"
-            aria-label="Project settings"
+            onClick={onShare}
+            title="Share this project"
             style={{
-              width: 34, height: 34, flexShrink: 0,
-              display: 'flex', alignItems: 'center', justifyContent: 'center',
-              background: menuOpen ? 'var(--bg-muted)' : 'transparent',
+              display: 'flex', alignItems: 'center', gap: 7, height: 34, padding: '0 13px', flexShrink: 0,
+              background: project.shared ? 'var(--accent-bg)' : 'transparent',
               border: '1px solid var(--border)',
-              borderRadius: 9,
-              cursor: 'pointer',
-              color: 'var(--text-secondary)',
+              borderRadius: 9, cursor: 'pointer',
+              color: project.shared ? 'var(--accent-text)' : 'var(--text-secondary)',
+              fontSize: 13, fontWeight: 600, whiteSpace: 'nowrap',
             }}
           >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-              <circle cx="8" cy="3" r="1.4" />
-              <circle cx="8" cy="8" r="1.4" />
-              <circle cx="8" cy="13" r="1.4" />
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="18" cy="5" r="3" />
+              <circle cx="6" cy="12" r="3" />
+              <circle cx="18" cy="19" r="3" />
+              <path d="M8.6 10.7l6.8-3.9M8.6 13.3l6.8 3.9" />
             </svg>
+            {project.shared ? 'Shared' : 'Share'}
           </button>
 
-          {menuOpen && (
+          {isOwner && (
+            <button
+              ref={menuBtnRef}
+              type="button"
+              onClick={() => setMenuOpen((m) => !m)}
+              title="Project settings"
+              aria-label="Project settings"
+              style={{
+                width: 34, height: 34, flexShrink: 0,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                background: menuOpen ? 'var(--bg-muted)' : 'transparent',
+                border: '1px solid var(--border)',
+                borderRadius: 9,
+                cursor: 'pointer',
+                color: 'var(--text-secondary)',
+              }}
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <circle cx="8" cy="3" r="1.4" />
+                <circle cx="8" cy="8" r="1.4" />
+                <circle cx="8" cy="13" r="1.4" />
+              </svg>
+            </button>
+          )}
+
+          {menuOpen && isOwner && (
             <SettingsMenu
               onEdit={() => { setMenuOpen(false); onEdit() }}
               onDelete={() => { setMenuOpen(false); onDelete() }}
@@ -444,7 +477,7 @@ export default function ProjectPage({
         {/* Memory — stacked inline on narrow widths so it never gets buried */}
         {narrow && (
           <div style={{ marginBottom: 22 }}>
-            <MemoryBox project={project} color={c} onSave={onSaveMemory} />
+            <MemoryBox project={project} color={c} onSave={onSaveMemory} readOnly={!isOwner} />
           </div>
         )}
 
@@ -527,7 +560,7 @@ export default function ProjectPage({
             flex: '0 0 320px',
             position: 'sticky', top: 24,
           }}>
-            <MemoryBox project={project} color={c} onSave={onSaveMemory} />
+            <MemoryBox project={project} color={c} onSave={onSaveMemory} readOnly={!isOwner} />
           </aside>
         )}
         {/* end two-column body */}
@@ -698,11 +731,13 @@ function SettingsMenu({
 // project (Pro-gated, server-side). Edited inline here: view → Edit → Save.
 
 function MemoryBox({
-  project, color, onSave,
+  project, color, onSave, readOnly,
 }: {
   project: ChatProject
   color: ReturnType<typeof colorById>
   onSave: (memory: string) => Promise<void>
+  /** Shared-with-me project: the memory belongs to the owner; no edit pencil. */
+  readOnly?: boolean
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft]     = useState(project.memory ?? '')
@@ -782,9 +817,9 @@ function MemoryBox({
                 <rect x="5" y="11" width="14" height="10" rx="2" />
                 <path d="M8 11V7a4 4 0 0 1 8 0v4" />
               </svg>
-              Only you
+              {readOnly ? 'Owner only' : 'Only you'}
             </span>
-            <button
+            {!readOnly && <button
               type="button"
               onClick={startEdit}
               title={memory ? 'Edit memory' : 'Add memory'}
@@ -802,7 +837,7 @@ function MemoryBox({
                 <path d="M4 20h4l10-10-4-4L4 16z" />
                 <path d="M13.5 6.5l4 4" />
               </svg>
-            </button>
+            </button>}
           </>
         )}
       </div>

--- a/src/app/app/ShareModal.tsx
+++ b/src/app/app/ShareModal.tsx
@@ -1,0 +1,377 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useApp } from './App'
+
+// ─── ShareModal ──────────────────────────────────────────────────────────────
+// One modal for both share targets: a single conversation or a whole Chat
+// Project (the team space). Shows the member list, pending invites, an
+// email-invite composer, and a copy-link button. Invite delivery is the
+// owner's channel of choice (copied link / prefilled email) — no SMTP
+// dependency in v1.
+
+interface Member {
+  user_id: string
+  role: 'owner' | 'editor'
+  display_name: string
+  email: string | null
+}
+
+interface PendingInvite {
+  id: string
+  token: string
+  email: string | null
+  created_at: string
+  expires_at: string
+}
+
+interface ShareModalProps {
+  target: { kind: 'conversation' | 'chat_project'; id: string; name: string }
+  onClose: () => void
+  /** Fired after a membership-affecting action (remove member, revoke). */
+  onMembershipChanged: () => void
+}
+
+const AVATAR_COLORS = ['#8b5cf6', '#0ea5e9', '#10b981', '#f59e0b', '#ef4444', '#ec4899', '#14b8a6']
+export function avatarColor(seed: string): string {
+  let h = 0
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) | 0
+  return AVATAR_COLORS[Math.abs(h) % AVATAR_COLORS.length]
+}
+
+export default function ShareModal({ target, onClose, onMembershipChanged }: ShareModalProps) {
+  const { myUserId } = useApp()
+  const [members, setMembers] = useState<Member[]>([])
+  const [invites, setInvites] = useState<PendingInvite[]>([])
+  const [loading, setLoading] = useState(true)
+  const [email, setEmail] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const targetQuery = target.kind === 'conversation'
+    ? `conversationId=${target.id}`
+    : `chatProjectId=${target.id}`
+
+  const flash = useCallback((msg: string) => {
+    if (noticeTimer.current) clearTimeout(noticeTimer.current)
+    setNotice(msg)
+    noticeTimer.current = setTimeout(() => setNotice(null), 2600)
+  }, [])
+  useEffect(() => () => { if (noticeTimer.current) clearTimeout(noticeTimer.current) }, [])
+
+  const reload = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/collab/members?${targetQuery}`)
+      if (!res.ok) { setError('Could not load members.'); return }
+      const data = await res.json() as { members: Member[]; invites: PendingInvite[] }
+      setMembers(data.members ?? [])
+      setInvites(data.invites ?? [])
+      setError(null)
+    } catch {
+      setError('Could not load members.')
+    } finally {
+      setLoading(false)
+    }
+  }, [targetQuery])
+
+  useEffect(() => { void reload() }, [reload])
+
+  // Esc closes
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const isOwner = members.find((m) => m.role === 'owner')?.user_id === myUserId
+
+  const createInvite = useCallback(async (boundEmail: string | null): Promise<string | null> => {
+    const res = await fetch('/api/collab/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        kind: target.kind,
+        conversationId: target.kind === 'conversation' ? target.id : undefined,
+        chatProjectId: target.kind === 'chat_project' ? target.id : undefined,
+        email: boundEmail ?? undefined,
+      }),
+    })
+    const data = await res.json().catch(() => ({})) as { joinUrl?: string; error?: string }
+    if (!res.ok || !data.joinUrl) {
+      setError(data.error === 'forbidden' ? 'You don’t have access to share this.' : 'Could not create the invite.')
+      return null
+    }
+    return data.joinUrl
+  }, [target])
+
+  // Copy a general (email-unbound, multi-use) link. Reuses a pending link
+  // invite when one exists so the modal doesn't mint a pile of tokens.
+  const copyLink = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      const existing = invites.find((i) => !i.email)
+      const url = existing
+        ? `${window.location.origin}/join/${existing.token}`
+        : await createInvite(null)
+      if (!url) return
+      await navigator.clipboard.writeText(url)
+      flash('Link copied — anyone who opens it joins as an editor.')
+      if (!existing) void reload()
+    } catch {
+      setError('Could not copy the link.')
+    } finally {
+      setBusy(false)
+    }
+  }, [invites, createInvite, flash, reload])
+
+  const sendEmailInvite = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault()
+    const addr = email.trim().toLowerCase()
+    if (!/.+@.+\..+/.test(addr)) { setError('Enter a valid email address.'); return }
+    setBusy(true)
+    setError(null)
+    try {
+      const url = await createInvite(addr)
+      if (!url) return
+      setEmail('')
+      await navigator.clipboard.writeText(url).catch(() => {})
+      // Hand off to the user's own mail client with everything prefilled.
+      const subject = encodeURIComponent(`Join "${target.name}" on Nodea`)
+      const body = encodeURIComponent(
+        `I'm sharing "${target.name}" with you on Nodea — open this link to join:\n\n${url}\n\n` +
+        `Sign in (or create a free account) with this email address and it'll appear in your sidebar.`,
+      )
+      window.open(`mailto:${addr}?subject=${subject}&body=${body}`, '_self')
+      flash(`Invite for ${addr} created — link copied & email drafted.`)
+      void reload()
+    } finally {
+      setBusy(false)
+    }
+  }, [email, createInvite, target.name, flash, reload])
+
+  const revokeInvite = useCallback(async (id: string) => {
+    await fetch(`/api/collab/invites?id=${id}`, { method: 'DELETE' }).catch(() => {})
+    void reload()
+  }, [reload])
+
+  const removeMember = useCallback(async (userId: string) => {
+    const q = target.kind === 'conversation'
+      ? `conversationId=${target.id}&userId=${userId}`
+      : `chatProjectId=${target.id}&userId=${userId}`
+    await fetch(`/api/collab/members?${q}`, { method: 'DELETE' }).catch(() => {})
+    onMembershipChanged()
+    void reload()
+  }, [target, onMembershipChanged, reload])
+
+  return (
+    <div
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 9000,
+        background: 'rgba(0,0,0,0.45)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20,
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Share ${target.name}`}
+        style={{
+          width: 440, maxWidth: '100%', maxHeight: '82vh', overflowY: 'auto',
+          background: 'var(--modal-bg)', color: 'var(--text-primary)',
+          border: '1px solid var(--border-strong)', borderRadius: 14,
+          boxShadow: 'var(--shadow-lg)', padding: 20,
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 4 }}>
+          <div>
+            <h2 style={{ fontSize: 16, fontWeight: 700 }}>
+              Share {target.kind === 'chat_project' ? 'project' : 'chat'}
+            </h2>
+            <div style={{ fontSize: 12.5, color: 'var(--text-muted)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 330 }}>
+              {target.name}
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            style={{ background: 'transparent', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', padding: 4, lineHeight: 0, borderRadius: 6 }}
+          >
+            <svg width="13" height="13" viewBox="0 0 12 12" fill="none">
+              <path d="M2 2l8 8M10 2l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        {target.kind === 'chat_project' && (
+          <p style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: 14 }}>
+            Members can open every chat in this project, reply, and branch. Each
+            person&rsquo;s AI usage counts against their own plan.
+          </p>
+        )}
+        {target.kind === 'conversation' && (
+          <p style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: 14 }}>
+            Members can read this chat, reply, and branch. Each person&rsquo;s AI
+            usage counts against their own plan.
+          </p>
+        )}
+
+        {/* Email invite */}
+        <form onSubmit={sendEmailInvite} style={{ display: 'flex', gap: 8, marginBottom: 10 }}>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="teammate@email.com"
+            style={{
+              flex: 1, padding: '8px 11px', borderRadius: 8,
+              border: '1.5px solid var(--border)', background: 'var(--input-bg)',
+              color: 'var(--text-primary)', fontSize: 13, outline: 'none',
+            }}
+          />
+          <button
+            type="submit"
+            disabled={busy || !email.trim()}
+            style={{
+              padding: '8px 14px', borderRadius: 8, border: 'none',
+              background: 'var(--accent)', color: '#fff', fontSize: 13, fontWeight: 600,
+              cursor: busy || !email.trim() ? 'default' : 'pointer',
+              opacity: busy || !email.trim() ? 0.6 : 1, whiteSpace: 'nowrap',
+            }}
+          >
+            Invite
+          </button>
+        </form>
+
+        {/* Copy link */}
+        <button
+          type="button"
+          onClick={() => void copyLink()}
+          disabled={busy}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 8, width: '100%',
+            padding: '8px 11px', marginBottom: 14,
+            background: 'transparent', border: '1.5px dashed var(--border-strong)', borderRadius: 8,
+            cursor: busy ? 'default' : 'pointer', color: 'var(--text-secondary)',
+            fontSize: 12.5, fontWeight: 600,
+          }}
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7" />
+            <path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7" />
+          </svg>
+          Copy invite link
+          <span style={{ marginLeft: 'auto', fontWeight: 400, fontSize: 11, color: 'var(--text-muted)' }}>
+            anyone with the link
+          </span>
+        </button>
+
+        {(notice || error) && (
+          <div
+            role="status"
+            style={{
+              fontSize: 12, padding: '7px 10px', borderRadius: 7, marginBottom: 12,
+              background: error ? 'var(--color-error-bg, rgba(239,68,68,0.12))' : 'var(--accent-bg)',
+              color: error ? 'var(--color-error, #ef4444)' : 'var(--accent-text)',
+            }}
+          >
+            {error ?? notice}
+          </div>
+        )}
+
+        {/* Members */}
+        <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '0.08em', color: 'var(--text-muted)', textTransform: 'uppercase', margin: '4px 0 6px' }}>
+          Members
+        </div>
+        {loading ? (
+          <div style={{ fontSize: 12.5, color: 'var(--text-muted)', padding: '6px 0 10px' }}>Loading…</div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 2, marginBottom: invites.length ? 12 : 0 }}>
+            {members.map((m) => (
+              <div key={m.user_id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 2px' }}>
+                <div style={{
+                  width: 26, height: 26, borderRadius: '50%', flexShrink: 0,
+                  background: avatarColor(m.user_id), color: '#fff',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 11.5, fontWeight: 700,
+                }}>
+                  {m.display_name.charAt(0).toUpperCase()}
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {m.display_name}{m.user_id === myUserId ? ' (you)' : ''}
+                  </div>
+                  {m.email && (
+                    <div style={{ fontSize: 11, color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {m.email}
+                    </div>
+                  )}
+                </div>
+                <span style={{ fontSize: 10.5, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                  {m.role}
+                </span>
+                {((isOwner && m.role !== 'owner') || (m.user_id === myUserId && m.role !== 'owner')) && (
+                  <button
+                    type="button"
+                    title={m.user_id === myUserId ? 'Leave' : 'Remove member'}
+                    onClick={() => void removeMember(m.user_id)}
+                    style={{ background: 'transparent', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', padding: 3, lineHeight: 0, borderRadius: 5 }}
+                  >
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                      <path d="M2 2l8 8M10 2l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                    </svg>
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Pending invites */}
+        {invites.length > 0 && (
+          <>
+            <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '0.08em', color: 'var(--text-muted)', textTransform: 'uppercase', margin: '4px 0 6px' }}>
+              Pending invites
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {invites.map((inv) => (
+                <div key={inv.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '5px 2px' }}>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+                    {inv.email
+                      ? <><rect x="3" y="5" width="18" height="14" rx="2" /><path d="M3 7l9 6 9-6" /></>
+                      : <><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7" /><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7" /></>}
+                  </svg>
+                  <span style={{ flex: 1, minWidth: 0, fontSize: 12.5, color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {inv.email ?? 'Invite link'}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void navigator.clipboard.writeText(`${window.location.origin}/join/${inv.token}`)
+                        .then(() => flash('Invite link copied.'))
+                    }}
+                    style={{ background: 'transparent', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', fontSize: 11.5, fontWeight: 600, padding: '2px 4px' }}
+                  >
+                    Copy
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void revokeInvite(inv.id)}
+                    style={{ background: 'transparent', border: 'none', cursor: 'pointer', color: 'var(--color-error, #ef4444)', fontSize: 11.5, fontWeight: 600, padding: '2px 4px' }}
+                  >
+                    Revoke
+                  </button>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/app/Sidebar.tsx
+++ b/src/app/app/Sidebar.tsx
@@ -22,6 +22,8 @@ export default function Sidebar() {
     openProjectsLanding, openProject, openNewProjectModal,
     openConvContext, openProjectContext, openChatView,
     assignConvToProject, requestNewChatInProject,
+    // ── Collaboration ──
+    myUserId,
   } = useApp()
 
   const [collapsed, setCollapsed] = useState(false)
@@ -123,8 +125,12 @@ export default function Sidebar() {
     ? conversations.filter((c) => c.chat_project_id !== activeChatProjectId)
     : conversations
 
-  // ── Pinned projects (cap at 3) ────────────────────────────────────────────
-  const pinned = chatProjects.filter((p) => p.pinned).slice(0, MAX_PINNED_PROJECTS)
+  // ── Pinned projects (cap at 3) — own projects only ────────────────────────
+  const pinned = chatProjects.filter((p) => p.pinned && !p.shared).slice(0, MAX_PINNED_PROJECTS)
+
+  // ── Projects shared with me (always visible, Pro or not) ──────────────────
+  const sharedProjects = chatProjects.filter((p) => p.shared)
+  const isSharedConv = (conv: Conversation) => !!myUserId && conv.user_id !== myUserId
 
   return (
     <div
@@ -377,6 +383,24 @@ export default function Sidebar() {
           )
         )}
 
+        {/* ── SHARED PROJECTS (team spaces I'm a member of) ── */}
+        {!collapsed && sharedProjects.length > 0 && (
+          <>
+            <SectionLabel>Shared with me</SectionLabel>
+            {sharedProjects.map((p) => (
+              <PinnedProject
+                key={p.id}
+                project={p}
+                active={p.id === activeChatProjectId && view === 'project'}
+                dropActive={dropTargetProject === p.id}
+                onClick={() => openProject(p.id)}
+                onContext={(x, y) => openProjectContext(p, x, y)}
+                {...dropHandlers(p.id)}
+              />
+            ))}
+          </>
+        )}
+
         {/* ── CONVERSATIONS ── */}
         {insideProject && activeProj && !collapsed && (
           <>
@@ -401,6 +425,7 @@ export default function Sidebar() {
               <ConvRow
                 key={conv.id}
                 conv={conv}
+                shared={isSharedConv(conv)}
                 isActive={conv.id === activeConvId}
                 isGenerating={inFlightConvIds.has(conv.id)}
                 isHovered={hoveredId === conv.id}
@@ -440,6 +465,7 @@ export default function Sidebar() {
           <ConvRow
             key={conv.id}
             conv={conv}
+            shared={isSharedConv(conv)}
             isActive={conv.id === activeConvId}
             isGenerating={inFlightConvIds.has(conv.id)}
             isHovered={hoveredId === conv.id}
@@ -668,6 +694,8 @@ function SourceBadge({ source }: { source?: string | null }) {
 
 interface ConvRowProps {
   conv: Conversation
+  /** Conversation owned by someone else, shared with me. */
+  shared?: boolean
   isActive: boolean
   isGenerating: boolean
   isHovered: boolean
@@ -687,7 +715,7 @@ interface ConvRowProps {
 
 function ConvRow(props: ConvRowProps) {
   const {
-    conv, isActive, isGenerating, isHovered, isEditing,
+    conv, shared, isActive, isGenerating, isHovered, isEditing,
     editingName, editInputRef, setHovered, setEditingName,
     onClick, onDoubleClick, onCommitEdit, onCancelEdit,
     onContext, projects, collapsed,
@@ -787,6 +815,15 @@ function ConvRow(props: ConvRowProps) {
           {!collapsed && (
             <>
               <SourceBadge source={conv.source} />
+              {shared && (
+                <span title="Shared with you" style={{ display: 'inline-flex', flexShrink: 0, color: 'var(--text-muted)', lineHeight: 0 }}>
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+                    <circle cx="9" cy="7" r="4" />
+                    <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+                  </svg>
+                </span>
+              )}
               <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, minWidth: 0 }}>
                 {conv.name}
               </span>

--- a/src/app/app/TreePanel.tsx
+++ b/src/app/app/TreePanel.tsx
@@ -770,8 +770,12 @@ export default function TreePanel() {
     })
   }, [activePairIds, pairPositions, fitView, nodeHMax])
 
-  // ── Smart zoom to newly-saved node ────────────────────────────────────────────
-  const smartZoomToNode = useCallback((pairId: string, chainLen: number) => {
+  // ── Center the working node front-and-center ──────────────────────────────────
+  // In autocenter mode the node you're working on — about to fork from, or just
+  // created — sits dead-centre in the viewport at a readable zoom. We preserve the
+  // user's current zoom when it's already legible, and only bump it up to the
+  // readable floor when they're zoomed too far out for the node to be useful.
+  const centerOnNode = useCallback((pairId: string) => {
     const el = containerRef.current
     if (!el) return
     const pos = pairPositions.get(pairId)
@@ -779,44 +783,45 @@ export default function TreePanel() {
 
     const cw = el.clientWidth
     const ch = el.clientHeight
+    if (cw === 0 || ch === 0) return
 
-    // Scale: fit the full chain height comfortably, clamped to readable range
-    const chainH = Math.max(1, chainLen - 1) * vSpacing + nodeHMax
-    const sByH   = (ch * 0.85) / chainH
-    const s      = Math.max(MIN_READABLE_SCALE, Math.min(1.1, sByH))
-
-    // Vertical position: fewer ancestors → node sits higher; more → bottom 25%
-    const MAX_CHAIN = 8
-    const t          = Math.min((chainLen - 1) / MAX_CHAIN, 1)
-    const targetY    = ch * (0.25 + 0.5 * t)  // 25% → 75% down
+    const s = Math.min(2.5, Math.max(MIN_READABLE_SCALE, scaleRef.current))
 
     setScale(s)
     setPan({
       x: cw / 2 - (pos.x + LAYOUT_W / 2) * s,
-      y: targetY  - (pos.y + nodeHMax / 2) * s,
+      y: ch / 2 - (pos.y + nodeHMax / 2) * s,
     })
-  }, [pairPositions, vSpacing, nodeHMax])
+  }, [pairPositions, nodeHMax])
 
+  // First load fits the whole tree; after that, autocenter drives the framing.
   useEffect(() => {
-    if (pairs.length > 0) {
-      if (!initialFitDone.current) {
-        initialFitDone.current = true
-        const t = setTimeout(fitView, 80)
-        return () => clearTimeout(t)
-      } else if (autoZoom) {
-        const t = setTimeout(fitView, 80)
-        return () => clearTimeout(t)
-      }
+    if (pairs.length > 0 && !initialFitDone.current) {
+      initialFitDone.current = true
+      const t = setTimeout(fitView, 80)
+      return () => clearTimeout(t)
     }
   }, [pairs.length]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── Auto-zoom on new message ──────────────────────────────────────────────────
+  // ── Autocenter: keep the node just made front-and-centre ──────────────────────
   useEffect(() => {
     if (!autoZoom || !lastSavedPairId) return
-    const chainLen = getActivePairIds(pairs, lastSavedPairId).size
-    const t = setTimeout(() => smartZoomToNode(lastSavedPairId, chainLen), 80)
+    const t = setTimeout(() => centerOnNode(lastSavedPairId), 80)
     return () => clearTimeout(t)
   }, [lastSavedPairId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Autocenter: keep the node you're working on / about to fork from centred ──
+  useEffect(() => {
+    if (!autoZoom || !selectedNodeId) return
+    const pair = pairs.find((p) =>
+      p.id === selectedNodeId ||
+      p.userNode.id === selectedNodeId ||
+      (p.aiNode && p.aiNode.id === selectedNodeId)
+    )
+    if (!pair) return
+    const t = setTimeout(() => centerOnNode(pair.id), 80)
+    return () => clearTimeout(t)
+  }, [selectedNodeId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Re-fit when view mode changes (full mode uses taller nodes) ──────────────
   useEffect(() => {

--- a/src/app/app/TreePanel.tsx
+++ b/src/app/app/TreePanel.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo, useState, useRef, useEffect, useCallback } from 'react'
 import { track } from '@vercel/analytics'
 import { useApp, type DbNode } from './App'
+import { DECISION_STATUSES, decisionMeta } from '@/lib/decisions'
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 const LAYOUT_W           = 240
@@ -11,11 +12,12 @@ const V_SPACING          = 180
 const GRID_PX            = 24
 const MIN_WIDTH          = 200
 const MAX_WIDTH          = 700
-const DEFAULT_WIDTH      = 320
+const DEFAULT_WIDTH      = 420
+const PANEL_WIDTH_KEY    = 'nodea_tree_panel_w'
 const MIN_READABLE_SCALE = 0.65
 
 const NODE_W      = { detailed: 240, compact: 190, mini: 150 } as const
-const NODE_H      = { detailed: 86,  compact: 52,  mini:  40  } as const
+const NODE_H      = { detailed: 104, compact: 52,  mini:  40  } as const
 const NODE_H_FULL = { detailed: 220, compact: 140, mini:  90  } as const
 const V_SPACING_FULL = 320
 
@@ -481,12 +483,18 @@ function StickyNoteCard({
 
 // ── Main component ─────────────────────────────────────────────────────────────
 export default function TreePanel() {
-  const { allDbNodes, selectedNodeId, handleNodeClick, nodeColors, setNodeColor, deleteNode, nodeSummaries, input, chatInputRef, lastSavedPairId, isLoading, isChatCollapsed, activeConvId, canMergeInto, addMergeSource, removeMergeSource, beginMerge } = useApp()
+  const { allDbNodes, selectedNodeId, handleNodeClick, nodeColors, setNodeColor, nodeDecisions, setNodeDecision, deleteNode, nodeSummaries, input, chatInputRef, lastSavedPairId, isLoading, isChatCollapsed, activeConvId, canMergeInto, addMergeSource, removeMergeSource, beginMerge } = useApp()
 
   const [collapsed,       setCollapsed]       = useState(false)
   const [viewMode,        setViewMode]        = useState<'tree' | 'outline' | 'full'>('tree')
   const [autoZoom,        setAutoZoom]        = useState(true)
   const [panelWidth,      setPanelWidth]      = useState(DEFAULT_WIDTH)
+
+  // Restore the user's last panel width (after mount, to avoid hydration mismatch).
+  useEffect(() => {
+    const saved = Number(localStorage.getItem(PANEL_WIDTH_KEY))
+    if (saved >= MIN_WIDTH && saved <= MAX_WIDTH) setPanelWidth(saved)
+  }, [])
   const [hoveredId,       setHoveredId]       = useState<string | null>(null)
   const [hoverPos,        setHoverPos]        = useState<{ x: number; y: number } | null>(null)
   const [colorMenu,       setColorMenu]       = useState<{ nodeId: string; x: number; y: number; confirmDelete?: boolean } | null>(null)
@@ -884,13 +892,16 @@ export default function TreePanel() {
     isResizing.current   = true
     resizeOrigin.current = { x: e.clientX, w: panelWidth }
 
+    let lastW = panelWidth
     function onMove(ev: MouseEvent) {
       if (!isResizing.current) return
       const delta = resizeOrigin.current.x - ev.clientX
-      setPanelWidth(Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, resizeOrigin.current.w + delta)))
+      lastW = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, resizeOrigin.current.w + delta))
+      setPanelWidth(lastW)
     }
     function onUp() {
       isResizing.current = false
+      localStorage.setItem(PANEL_WIDTH_KEY, String(lastW))
       window.removeEventListener('mousemove', onMove)
       window.removeEventListener('mouseup', onUp)
     }
@@ -1316,6 +1327,7 @@ export default function TreePanel() {
                 const isHovered  = pair.id === hoveredId
                 const isInactive = activePairIds.size > 0 && !isOnPath
                 const color      = nodeColors[pair.id] || nodeColors[pair.userNode.id] || (pair.aiNode ? nodeColors[pair.aiNode.id] : '') || ''
+                const decision   = nodeDecisions[pair.id] || nodeDecisions[pair.userNode.id] || (pair.aiNode ? nodeDecisions[pair.aiNode.id] : undefined)
 
                 const aiMeta  = nodeSummaries[pair.id]
                 const title   = aiMeta?.title   || generateTitle(pair.userNode.content, pair.aiNode?.content ?? '')
@@ -1459,6 +1471,28 @@ export default function TreePanel() {
                         </span>
                       </div>
                     )}
+
+                    {/* Decision tag badge (top-right). */}
+                    {decision && (() => {
+                      const m = decisionMeta(decision.status)
+                      return (
+                        <div
+                          title={`${m.label}${decision.note ? ' — ' + decision.note : ''}`}
+                          style={{
+                            position: 'absolute', right: -6, top: -8, zIndex: 6,
+                            height: 18, padding: '0 7px', borderRadius: 9,
+                            display: 'flex', alignItems: 'center', gap: 4,
+                            fontSize: 9.5, fontWeight: 700, whiteSpace: 'nowrap',
+                            background: 'var(--modal-bg)', color: m.color,
+                            border: `1.5px solid ${m.color}`, boxShadow: '0 1px 3px rgba(0,0,0,0.18)',
+                            pointerEvents: 'none',
+                          }}
+                        >
+                          <span style={{ width: 7, height: 7, borderRadius: '50%', background: m.color, flexShrink: 0 }} />
+                          {m.label}
+                        </div>
+                      )
+                    })()}
                     <div
                       data-node="true"
                       onClick={(e) => onNodeActivate(pair, e)}
@@ -1479,12 +1513,26 @@ export default function TreePanel() {
                       {zoomMode === 'detailed' && viewMode === 'tree' && (
                         <div style={{ padding: '9px 10px 8px 10px', height: '100%', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', gap: 3 }}>
                           <div style={{ display: 'flex', alignItems: 'center', gap: 5, minWidth: 0 }}>
-                            <span style={{ fontSize: 11.5, fontWeight: 600, color: 'var(--text-primary)', lineHeight: 1.3, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            <span
+                              style={{
+                                fontSize: 11.5, fontWeight: 600, color: 'var(--text-primary)', lineHeight: 1.3, flex: 1,
+                                overflow: 'hidden',
+                                display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: 2,
+                                wordBreak: 'break-word',
+                              }}
+                            >
                               {title}
                             </span>
                           </div>
                           {summary && (
-                            <div style={{ fontSize: 10.5, color: 'var(--text-secondary)', lineHeight: 1.4, overflow: 'hidden', maxHeight: hasAttachments ? 16 : 32 }}>
+                            <div
+                              style={{
+                                fontSize: 10.5, color: 'var(--text-secondary)', lineHeight: 1.45,
+                                overflow: 'hidden',
+                                display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: hasAttachments ? 2 : 3,
+                                wordBreak: 'break-word',
+                              }}
+                            >
                               {summary}
                             </div>
                           )}
@@ -2056,7 +2104,7 @@ export default function TreePanel() {
       {colorMenu && (
         <div
           onClick={e => e.stopPropagation()}
-          style={{ position: 'fixed', left: colorMenu.x, top: colorMenu.y, background: 'var(--modal-bg)', border: '1px solid var(--border-strong)', borderRadius: 12, padding: '10px 12px', boxShadow: 'var(--shadow-lg)', zIndex: 9999, minWidth: 144 }}
+          style={{ position: 'fixed', left: colorMenu.x, top: colorMenu.y, background: 'var(--modal-bg)', border: '1px solid var(--border-strong)', borderRadius: 12, padding: '10px 12px', boxShadow: 'var(--shadow-lg)', zIndex: 9999, minWidth: 210 }}
         >
           <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-muted)', marginBottom: 8, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
             Node colour
@@ -2078,6 +2126,52 @@ export default function TreePanel() {
               )
             })}
           </div>
+
+          {/* Decision tag — mark where this branch sits in a decision. */}
+          <div style={{ height: 1, background: 'var(--border)', margin: '11px 0 8px' }} />
+          <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-muted)', marginBottom: 8, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+            Decision
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+            {DECISION_STATUSES.map(s => {
+              const cur    = nodeDecisions[colorMenu.nodeId]
+              const active = (cur?.status ?? null) === s.id
+              return (
+                <button key={s.id} type="button" title={s.description}
+                  onClick={() => {
+                    setNodeDecision(colorMenu.nodeId, active ? null : s.id, cur?.note ?? null)
+                    track('node_decision_tagged', { status: active ? 'cleared' : s.id })
+                  }}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 5,
+                    padding: '4px 8px', borderRadius: 7, fontSize: 11.5, fontWeight: 500,
+                    cursor: 'pointer', whiteSpace: 'nowrap',
+                    border: active ? `1.5px solid ${s.color}` : '1px solid var(--border)',
+                    background: active ? `${s.color}1a` : 'transparent',
+                    color: active ? s.color : 'var(--text-secondary)',
+                  }}
+                >
+                  <span style={{ width: 8, height: 8, borderRadius: '50%', background: s.color, flexShrink: 0 }} />
+                  {s.label}
+                </button>
+              )
+            })}
+          </div>
+          {nodeDecisions[colorMenu.nodeId] && (
+            <input
+              key={`note-${colorMenu.nodeId}`}
+              defaultValue={nodeDecisions[colorMenu.nodeId]?.note ?? ''}
+              placeholder="Why? (optional)"
+              onClick={e => e.stopPropagation()}
+              onBlur={e => {
+                const note = e.target.value.trim() || null
+                const status = nodeDecisions[colorMenu.nodeId]?.status
+                if (status && note !== (nodeDecisions[colorMenu.nodeId]?.note ?? null)) setNodeDecision(colorMenu.nodeId, status, note)
+              }}
+              onKeyDown={e => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
+              style={{ marginTop: 8, width: '100%', boxSizing: 'border-box', padding: '6px 8px', fontSize: 12, borderRadius: 7, border: '1px solid var(--border)', background: 'var(--bg-subtle)', color: 'var(--text-primary)', outline: 'none' }}
+            />
+          )}
 
           {/* Delete node — only for leaf pairs; blocked when branches fork below */}
           <div style={{ height: 1, background: 'var(--border)', margin: '11px 0 8px' }} />

--- a/src/app/app/chatProjectTypes.ts
+++ b/src/app/app/chatProjectTypes.ts
@@ -19,6 +19,13 @@ export interface ChatProject {
   chat_count: number
   /** ISO timestamp of the most recently created conversation in this project, or null if empty. */
   last_activity: string | null
+  /** Present on rows from /api/collab/shared: this project belongs to someone
+   *  else and was shared with me. */
+  shared?: boolean
+  /** Owner id (present on shared rows). */
+  user_id?: string
+  /** Owner display name for "Shared by …" (shared rows only). */
+  owner_name?: string | null
 }
 
 export type ProjectView = 'chat' | 'projects' | 'project'

--- a/src/app/join/[token]/page.tsx
+++ b/src/app/join/[token]/page.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { use, useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createClient } from '@/lib/supabase'
+import { PENDING_JOIN_KEY } from '@/lib/collab-client'
+
+// ─── /join/[token] — open an invite link ─────────────────────────────────────
+// Signed in → accept immediately (mints the membership) and land inside the
+// shared space. Signed out → park the token in localStorage and bounce to
+// /login; the app shell replays it after auth (see PENDING_JOIN_KEY in App).
+// This survives the /welcome detour new signups take, because the replay
+// happens on /app, not here.
+
+const ERROR_COPY: Record<string, string> = {
+  invite_not_found: 'This invite link is invalid — it may have been revoked.',
+  invite_expired: 'This invite link has expired. Ask for a fresh one.',
+  invite_email_mismatch:
+    'This invite was sent to a different email address. Sign in with the invited account to join.',
+  space_gone: 'The shared space behind this invite no longer exists.',
+}
+
+export default function JoinPage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = use(params)
+  const router = useRouter()
+  const [status, setStatus] = useState<'working' | 'error'>('working')
+  const [message, setMessage] = useState('Checking your invite…')
+  const ranRef = useRef(false)
+
+  useEffect(() => {
+    if (ranRef.current) return  // Strict Mode double-effect guard
+    ranRef.current = true
+
+    async function run() {
+      const supabase = createClient()
+      const { data: { user } } = await supabase.auth.getUser()
+
+      if (!user) {
+        try { localStorage.setItem(PENDING_JOIN_KEY, token) } catch {}
+        router.replace('/login')
+        return
+      }
+
+      const res = await fetch('/api/collab/accept', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      })
+      const data = await res.json().catch(() => ({})) as {
+        ok?: boolean; kind?: string; id?: string; error?: string
+      }
+
+      if (!res.ok || !data.ok || !data.id) {
+        setStatus('error')
+        setMessage(ERROR_COPY[data.error ?? ''] ?? 'Something went wrong opening this invite.')
+        return
+      }
+
+      setMessage('You’re in — opening the shared space…')
+      const dest = data.kind === 'chat_project'
+        ? `/app?project=${data.id}`
+        : `/app?conv=${data.id}`
+      router.replace(dest)
+    }
+    void run()
+  }, [token, router])
+
+  return (
+    <div style={{
+      minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: 'var(--bg-base, #0d0d10)', color: 'var(--text-primary, #e7e7ea)',
+      fontFamily: 'system-ui, sans-serif', padding: 24,
+    }}>
+      <div style={{ textAlign: 'center', maxWidth: 420 }}>
+        <div style={{ fontSize: 22, fontWeight: 700, color: '#8b5cf6', marginBottom: 14 }}>Nodea</div>
+        {status === 'working' && (
+          <div aria-hidden style={{
+            width: 22, height: 22, margin: '0 auto 14px', borderRadius: '50%',
+            border: '2.5px solid rgba(139,92,246,0.25)', borderTopColor: '#8b5cf6',
+            animation: 'nodea-join-spin 0.8s linear infinite',
+          }} />
+        )}
+        <p style={{ fontSize: 15, lineHeight: 1.5 }}>{message}</p>
+        {status === 'error' && (
+          <a href="/app" style={{ display: 'inline-block', marginTop: 16, color: '#8b5cf6', fontWeight: 600, fontSize: 14 }}>
+            Go to your canvas →
+          </a>
+        )}
+        <style>{'@keyframes nodea-join-spin { to { transform: rotate(360deg) } }'}</style>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/collab-client.ts
+++ b/src/lib/collab-client.ts
@@ -1,0 +1,6 @@
+// Client-side collaboration constants shared between the /join page and the
+// app shell (kept out of both so neither pulls the other's bundle).
+
+/** localStorage slot where /join parks an invite token while the visitor
+ *  signs in / signs up; the app shell replays it on the next /app load. */
+export const PENDING_JOIN_KEY = 'nodea_pending_join'

--- a/src/lib/collab.ts
+++ b/src/lib/collab.ts
@@ -1,0 +1,116 @@
+import type { SupabaseClient, User } from '@supabase/supabase-js'
+
+// ─── Collaboration server helpers ────────────────────────────────────────────
+// Shared by the /api/collab/* routes. Access checks lean on the same membership
+// model the RLS policies enforce (migration 20260612000000_collaboration) —
+// these run with the service client only where the caller's own RLS view
+// isn't enough (accepting an invite, resolving member profiles).
+
+export type InviteKind = 'chat_project' | 'conversation'
+
+export interface CollabInviteRow {
+  id: string
+  token: string
+  kind: InviteKind
+  chat_project_id: string | null
+  project_id: string | null
+  email: string | null
+  role: string
+  invited_by: string
+  created_at: string
+  expires_at: string
+}
+
+export interface MemberProfile {
+  user_id: string
+  display_name: string
+  email: string | null
+  role: 'owner' | 'editor'
+}
+
+/** Whether `userId` may access the conversation: owner, direct member, or
+ *  member of the Chat Project it's filed under. Service-client query (the
+ *  caller's identity is already verified by the route). */
+export async function canAccessConversation(
+  service: SupabaseClient,
+  projectId: string,
+  userId: string,
+): Promise<boolean> {
+  const { data: proj } = await service
+    .from('projects')
+    .select('user_id, chat_project_id')
+    .eq('id', projectId)
+    .maybeSingle()
+  if (!proj) return false
+  if (proj.user_id === userId) return true
+
+  const { data: direct } = await service
+    .from('conversation_members')
+    .select('user_id')
+    .eq('project_id', projectId)
+    .eq('user_id', userId)
+    .maybeSingle()
+  if (direct) return true
+
+  if (proj.chat_project_id) {
+    const { data: viaProject } = await service
+      .from('chat_project_members')
+      .select('user_id')
+      .eq('chat_project_id', proj.chat_project_id)
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (viaProject) return true
+  }
+  return false
+}
+
+/** Whether `userId` may access the Chat Project: owner or member. */
+export async function canAccessChatProject(
+  service: SupabaseClient,
+  chatProjectId: string,
+  userId: string,
+): Promise<boolean> {
+  const { data: cp } = await service
+    .from('chat_projects')
+    .select('user_id')
+    .eq('id', chatProjectId)
+    .maybeSingle()
+  if (!cp) return false
+  if (cp.user_id === userId) return true
+  const { data: member } = await service
+    .from('chat_project_members')
+    .select('user_id')
+    .eq('chat_project_id', chatProjectId)
+    .eq('user_id', userId)
+    .maybeSingle()
+  return !!member
+}
+
+/** Resolve display profiles for a set of user ids via the Auth admin API.
+ *  Display names come from user_metadata.display_name (set on /welcome). */
+export async function resolveProfiles(
+  service: SupabaseClient,
+  userIds: string[],
+): Promise<Map<string, { display_name: string; email: string | null }>> {
+  const out = new Map<string, { display_name: string; email: string | null }>()
+  await Promise.all(
+    [...new Set(userIds)].map(async (id) => {
+      try {
+        const { data, error } = await service.auth.admin.getUserById(id)
+        if (error || !data.user) return
+        out.set(id, profileFromUser(data.user))
+      } catch {
+        // Skip unresolvable users (deleted accounts) — caller falls back.
+      }
+    }),
+  )
+  return out
+}
+
+export function profileFromUser(u: User): { display_name: string; email: string | null } {
+  const meta = (u.user_metadata ?? {}) as { display_name?: unknown }
+  const name = typeof meta.display_name === 'string' && meta.display_name.trim()
+    ? meta.display_name.trim()
+    : (u.email?.split('@')[0] ?? 'Member')
+  return { display_name: name, email: u.email ?? null }
+}

--- a/supabase/migrations/20260612000000_collaboration.sql
+++ b/supabase/migrations/20260612000000_collaboration.sql
@@ -1,0 +1,306 @@
+-- Collaboration foundation: shared Chat Projects + shared one-off conversations.
+--
+-- Design (additive — every existing owner-only policy stays untouched):
+--   • Membership tables record who else can access a space. Ownership stays on
+--     the existing user_id columns; the owner never gets a membership row.
+--   • chat_project_members  — members of a shared Chat Project (the team space).
+--     Every conversation filed under that project inherits access.
+--   • conversation_members  — members of a single shared conversation (one-off
+--     chat shared by link), independent of any project.
+--   • collab_invites        — pending invites. A token link mints a membership
+--     row when opened (server-side, service role); from then on access flows
+--     from membership, never from the token.
+--   • nodes.created_by      — author attribution for shared trees.
+--
+-- RLS strategy: permissive policies OR together, so we ADD member policies
+-- alongside the pre-migration owner policies (whose exact predicates live in
+-- the base schema and aren't restated here). Membership checks go through
+-- SECURITY DEFINER helpers so policies on projects/nodes can read the
+-- membership tables without recursive RLS evaluation.
+-- Token billing is untouched: /api/chat meters the authenticated *sender*.
+
+
+-- ── Membership tables ─────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.chat_project_members (
+  chat_project_id UUID        NOT NULL REFERENCES public.chat_projects(id) ON DELETE CASCADE,
+  user_id         UUID        NOT NULL REFERENCES auth.users(id)           ON DELETE CASCADE,
+  role            TEXT        NOT NULL DEFAULT 'editor' CHECK (role IN ('editor')),
+  invited_by      UUID                 REFERENCES auth.users(id)           ON DELETE SET NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (chat_project_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS chat_project_members_user_idx
+  ON public.chat_project_members (user_id);
+
+CREATE TABLE IF NOT EXISTS public.conversation_members (
+  project_id  UUID        NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  user_id     UUID        NOT NULL REFERENCES auth.users(id)      ON DELETE CASCADE,
+  role        TEXT        NOT NULL DEFAULT 'editor' CHECK (role IN ('editor')),
+  invited_by  UUID                 REFERENCES auth.users(id)      ON DELETE SET NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS conversation_members_user_idx
+  ON public.conversation_members (user_id);
+
+CREATE TABLE IF NOT EXISTS public.collab_invites (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  token           TEXT        NOT NULL UNIQUE,
+  kind            TEXT        NOT NULL CHECK (kind IN ('chat_project', 'conversation')),
+  chat_project_id UUID                 REFERENCES public.chat_projects(id) ON DELETE CASCADE,
+  project_id      UUID                 REFERENCES public.projects(id)      ON DELETE CASCADE,
+  -- When set, only an account with this email may accept (email invite).
+  -- NULL = open link invite (anyone with the URL who signs in).
+  email           TEXT,
+  role            TEXT        NOT NULL DEFAULT 'editor' CHECK (role IN ('editor')),
+  invited_by      UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at      TIMESTAMPTZ NOT NULL DEFAULT now() + INTERVAL '14 days',
+  CHECK (
+    (kind = 'chat_project'  AND chat_project_id IS NOT NULL AND project_id IS NULL) OR
+    (kind = 'conversation'  AND project_id      IS NOT NULL AND chat_project_id IS NULL)
+  )
+);
+CREATE INDEX IF NOT EXISTS collab_invites_chat_project_idx
+  ON public.collab_invites (chat_project_id) WHERE chat_project_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS collab_invites_project_idx
+  ON public.collab_invites (project_id) WHERE project_id IS NOT NULL;
+
+ALTER TABLE public.chat_project_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.conversation_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.collab_invites       ENABLE ROW LEVEL SECURITY;
+
+
+-- ── Author attribution on nodes ───────────────────────────────────────────────
+
+ALTER TABLE public.nodes
+  ADD COLUMN IF NOT EXISTS created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+
+-- Backfill: everything written before collaboration was authored by the
+-- conversation's owner.
+UPDATE public.nodes n
+SET created_by = p.user_id
+FROM public.projects p
+WHERE n.project_id = p.id AND n.created_by IS NULL;
+
+
+-- ── Access helpers (SECURITY DEFINER → bypass RLS, no recursion) ─────────────
+-- STABLE + empty search_path per the advisor-warnings conventions. These are
+-- the single source of truth for "may this user touch this space".
+
+CREATE OR REPLACE FUNCTION public.can_access_chat_project(cp_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.chat_projects cp
+    WHERE cp.id = cp_id AND cp.user_id = auth.uid()
+  ) OR EXISTS (
+    SELECT 1 FROM public.chat_project_members m
+    WHERE m.chat_project_id = cp_id AND m.user_id = auth.uid()
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_access_project(p_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.projects p
+    WHERE p.id = p_id AND p.user_id = auth.uid()
+  ) OR EXISTS (
+    SELECT 1 FROM public.conversation_members cm
+    WHERE cm.project_id = p_id AND cm.user_id = auth.uid()
+  ) OR EXISTS (
+    SELECT 1
+    FROM public.projects p
+    JOIN public.chat_project_members m ON m.chat_project_id = p.chat_project_id
+    WHERE p.id = p_id AND m.user_id = auth.uid()
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_chat_project_owner(cp_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.chat_projects cp
+    WHERE cp.id = cp_id AND cp.user_id = auth.uid()
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_project_owner(p_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.projects p
+    WHERE p.id = p_id AND p.user_id = auth.uid()
+  );
+$$;
+
+
+-- ── Membership table policies ────────────────────────────────────────────────
+-- INSERT is deliberately absent: membership rows are only minted server-side
+-- (service role) when an invite is accepted, so a client can never add itself.
+
+CREATE POLICY "collab_select_chat_project_members"
+  ON public.chat_project_members FOR SELECT TO authenticated
+  USING (user_id = auth.uid() OR public.can_access_chat_project(chat_project_id));
+
+-- A member may leave; the project owner may remove anyone.
+CREATE POLICY "collab_delete_chat_project_members"
+  ON public.chat_project_members FOR DELETE TO authenticated
+  USING (user_id = auth.uid() OR public.is_chat_project_owner(chat_project_id));
+
+CREATE POLICY "collab_select_conversation_members"
+  ON public.conversation_members FOR SELECT TO authenticated
+  USING (user_id = auth.uid() OR public.can_access_project(project_id));
+
+CREATE POLICY "collab_delete_conversation_members"
+  ON public.conversation_members FOR DELETE TO authenticated
+  USING (user_id = auth.uid() OR public.is_project_owner(project_id));
+
+
+-- ── Invite policies ──────────────────────────────────────────────────────────
+-- Any member of a space may invite others to it (Google-Docs-style). Accepting
+-- runs server-side, so no by-token SELECT path exists for outsiders.
+
+CREATE POLICY "collab_select_invites"
+  ON public.collab_invites FOR SELECT TO authenticated
+  USING (
+    invited_by = auth.uid()
+    OR (kind = 'chat_project' AND public.can_access_chat_project(chat_project_id))
+    OR (kind = 'conversation' AND public.can_access_project(project_id))
+  );
+
+CREATE POLICY "collab_insert_invites"
+  ON public.collab_invites FOR INSERT TO authenticated
+  WITH CHECK (
+    invited_by = auth.uid()
+    AND (
+      (kind = 'chat_project' AND public.can_access_chat_project(chat_project_id))
+      OR (kind = 'conversation' AND public.can_access_project(project_id))
+    )
+  );
+
+CREATE POLICY "collab_delete_invites"
+  ON public.collab_invites FOR DELETE TO authenticated
+  USING (
+    invited_by = auth.uid()
+    OR (kind = 'chat_project' AND public.is_chat_project_owner(chat_project_id))
+    OR (kind = 'conversation' AND public.is_project_owner(project_id))
+  );
+
+
+-- ── Widen access: conversations (projects) ───────────────────────────────────
+-- Additive member policies; the base-schema owner policies keep working as-is.
+-- Members may read and rename/recolor a shared conversation, but only the
+-- owner may DELETE it or INSERT new ones under their own user_id (existing
+-- policies). New conversations a member starts inside a shared Chat Project
+-- are inserted under the member's own user_id (they own that conversation),
+-- and other members see it through the chat_project_members join above.
+
+CREATE POLICY "collab_select_projects"
+  ON public.projects FOR SELECT TO authenticated
+  USING (public.can_access_project(id));
+
+CREATE POLICY "collab_update_projects"
+  ON public.projects FOR UPDATE TO authenticated
+  USING (public.can_access_project(id))
+  WITH CHECK (public.can_access_project(id));
+
+-- The member UPDATE policy above can't stop a row from being re-owned
+-- (WITH CHECK can't see OLD values), so take user_id/is_default off the
+-- updatable column list instead. No client code updates either column.
+-- Built dynamically because the hosted schema may lag the migrations folder
+-- (e.g. the tree-summary columns) — grant whichever safe columns exist.
+DO $grants$
+DECLARE cols TEXT;
+BEGIN
+  SELECT string_agg(quote_ident(column_name), ', ')
+  INTO cols
+  FROM information_schema.columns
+  WHERE table_schema = 'public' AND table_name = 'projects'
+    AND column_name IN (
+      'name', 'color', 'chat_project_id',
+      'source', 'source_conversation_id', 'source_org_id', 'source_leaf_id', 'source_synced_at',
+      'summary', 'summary_open_loops', 'summary_node_count', 'summary_updated_at'
+    );
+  REVOKE UPDATE ON public.projects FROM authenticated;
+  IF cols IS NOT NULL THEN
+    EXECUTE format('GRANT UPDATE (%s) ON public.projects TO authenticated', cols);
+  END IF;
+END $grants$;
+
+
+-- ── Widen access: chat_projects (shared team spaces) ─────────────────────────
+-- Members can see the project. Editing its settings/memory and deleting it
+-- stay owner-only (the API routes also enforce this server-side).
+
+CREATE POLICY "collab_select_chat_projects"
+  ON public.chat_projects FOR SELECT TO authenticated
+  USING (public.can_access_chat_project(id));
+
+
+-- ── Widen access: nodes (the message tree) ───────────────────────────────────
+-- Members get full tree access in spaces they belong to. Inserts must be
+-- authored honestly: created_by is the caller (or NULL from legacy paths).
+
+CREATE POLICY "collab_select_nodes"
+  ON public.nodes FOR SELECT TO authenticated
+  USING (public.can_access_project(project_id));
+
+CREATE POLICY "collab_insert_nodes"
+  ON public.nodes FOR INSERT TO authenticated
+  WITH CHECK (
+    public.can_access_project(project_id)
+    AND (created_by IS NULL OR created_by = auth.uid())
+  );
+
+CREATE POLICY "collab_update_nodes"
+  ON public.nodes FOR UPDATE TO authenticated
+  USING (public.can_access_project(project_id))
+  WITH CHECK (public.can_access_project(project_id));
+
+CREATE POLICY "collab_delete_nodes"
+  ON public.nodes FOR DELETE TO authenticated
+  USING (public.can_access_project(project_id));
+
+-- Same column-clamp as projects: client updates touch only canvas metadata,
+-- so project_id (re-parenting), role/content (rewriting history), and
+-- created_by (attribution spoofing) come off the updatable list.
+DO $grants$
+DECLARE cols TEXT;
+BEGIN
+  SELECT string_agg(quote_ident(column_name), ', ')
+  INTO cols
+  FROM information_schema.columns
+  WHERE table_schema = 'public' AND table_name = 'nodes'
+    AND column_name IN ('color', 'merge_sources', 'position_x', 'position_y');
+  REVOKE UPDATE ON public.nodes FROM authenticated;
+  IF cols IS NOT NULL THEN
+    EXECUTE format('GRANT UPDATE (%s) ON public.nodes TO authenticated', cols);
+  END IF;
+END $grants$;
+
+
+-- ── Realtime ─────────────────────────────────────────────────────────────────
+-- Live tree sync: clients subscribe to postgres_changes on nodes filtered by
+-- project_id. WALRUS enforces the SELECT policies above per subscriber, so a
+-- member only ever receives events for trees they can already read.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public' AND tablename = 'nodes'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.nodes;
+  END IF;
+END $$;


### PR DESCRIPTION
## What this is

Nodea goes multiplayer. Share a whole Chat Project (the team space — the anchor use case) or a single conversation. Opening an invite adds the space to the recipient's sidebar permanently; trees sync live between members; every message is author-attributed.

## How it works

**Data layer** (migration `20260612000000_collaboration.sql` — **already applied to prod & verified**, additive/backward-compatible):
- `chat_project_members` / `conversation_members` — membership; owner stays on existing `user_id` columns
- `collab_invites` — tokenized invites (email-bound single-use, or multi-use links, 14-day expiry)
- `nodes.created_by` — author attribution, backfilled to conversation owners
- Additive RLS via SECURITY DEFINER helpers (`can_access_project` / `can_access_chat_project`); column-level UPDATE grants stop re-owning rows or spoofing attribution
- `nodes` added to the realtime publication (WALRUS enforces member-scoped events)

**API**: POST/DELETE `/api/collab/invites`, POST `/api/collab/accept` (mints membership server-side), GET/DELETE `/api/collab/members` (+author profiles), GET `/api/collab/shared`, `/join/[token]` page (parks token through login/signup, replays on /app).

**App shell**: share modal (member list, email invite via prefilled mailto + copy-link, revoke), Shared-with-me sidebar section + badges, author avatar chips, presence avatars in the top bar, live node sync into the canvas (append-only tree = conflict-free), member-safe semantics (delete→leave, no auto-reap of others' convs, owner-only project settings/memory).

**Billing**: per sender — `/api/chat` already meters the authenticated caller; the assistant node is attributed to whoever prompted it. Free members get free-tier limits/models even in a Pro owner's project.

## Verified
- RLS proven against prod with simulated JWTs: member sees shared project/conv/nodes/member-list; stranger sees zero rows; member inserts authored nodes; test fixture fully cleaned
- Authenticated E2E on dev: app boots with merged shared lists, invite create→join→deep-link loop, member/profile resolution, invite revoke
- Logged-out join: token parked through /login
- tsc clean, production build green

## Not yet covered
- True two-account live test (presence + realtime between two browsers) — needs a second account; the RLS layer it rides on is SQL-verified
- Remote node **deletions** don't live-sync (appear on reload) — postgres_changes DELETE events can't be filtered per-project
- Invite emails aren't sent by us (copy-link + mailto handoff); wire Resend later if wanted

Includes 654e43f (canvas autocenter fix) from a parallel session on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)